### PR TITLE
Add gpio interrupt tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,9 @@ test_time_single: TESTS=-DTEST_TIME_SINGLE
 # Digital IO tests targets
 test_digitalio_single: TESTS=-DTEST_DIGITALIO_SINGLE
 
+# GPIO Interrupts tests targets
+test_interrupts_single: TESTS=-DTEST_INTERRUPTS_SINGLE
+
 ## CAN tests targets
 test_can_single: TESTS=-DTEST_CAN_SINGLE
 test_can_connected2_node1: TESTS=-DTEST_CAN_CONNECTED2_NODE1

--- a/src/corelibs/digitalio/test_digitalio_single.cpp
+++ b/src/corelibs/digitalio/test_digitalio_single.cpp
@@ -2,7 +2,7 @@
  *
  * This test is used to verify the functionality of the Digital IO module.
  * only one board is needed with TEST_DIGITALIO_OUTPUT pin connected to 
- * TEST_DIGITALIO_INPUT_1 pin for the test cases to work as expected.
+ * TEST_DIGITALIO_INPUT pin for the test cases to work as expected.
  */
 
 // std includes
@@ -40,10 +40,7 @@ TEST_GROUP(digitalio_single_internal);
 /**
  * @brief Setup method called by Unity before every test in this test group.
  */
-static TEST_SETUP(digitalio_single_internal)
-{ 
-    pinMode(TEST_DIGITALIO_OUTPUT, OUTPUT);
-    pinMode(TEST_DIGITALIO_INPUT_1, INPUT);
+static TEST_SETUP(digitalio_single_internal) { 
 }
 
 /**
@@ -55,93 +52,71 @@ static TEST_TEAR_DOWN(digitalio_single_internal) {
 /**
  * @brief This test is to verify digitalWrite and digitalRead functions when input pin is set to INPUT mode.
  * 
- * @note: Assumption is made that TEST_DIGITALIO_OUTPUT is connected to TEST_DIGITALIO_INPUT_1
+ * @note: Assumption is made that TEST_DIGITALIO_OUTPUT is connected to TEST_DIGITALIO_INPUT
  *       for the test cases to work as expected.
  */
 TEST_IFX(digitalio_single_internal, test_digitalio_read_write_input_normal)
 {
+    pinMode(TEST_DIGITALIO_OUTPUT, OUTPUT);
+    pinMode(TEST_DIGITALIO_INPUT, INPUT);
+
     digitalWrite(TEST_DIGITALIO_OUTPUT, HIGH);
-    TEST_ASSERT_EQUAL_MESSAGE(HIGH, digitalRead(TEST_DIGITALIO_INPUT_1), "Input Pin should be set to HIGH");
+    TEST_ASSERT_EQUAL_MESSAGE(HIGH, digitalRead(TEST_DIGITALIO_INPUT), "Input Pin should be set to HIGH");
     digitalWrite(TEST_DIGITALIO_OUTPUT, LOW);
-    TEST_ASSERT_EQUAL_MESSAGE(LOW, digitalRead(TEST_DIGITALIO_INPUT_1), "Input Pin should be set to LOW");
+    TEST_ASSERT_EQUAL_MESSAGE(LOW, digitalRead(TEST_DIGITALIO_INPUT), "Input Pin should be set to LOW");
 }
 
 /**
  * @brief This test is to verify digitalWrite and digitalRead functions when input pin is set to INPUT_PULLUP mode.
  * 
- * @note: Assumption is made that TEST_DIGITALIO_OUTPUT is connected to TEST_DIGITALIO_INPUT_1
+ * @note: Assumption is made that TEST_DIGITALIO_OUTPUT is connected to TEST_DIGITALIO_INPUT
  *       for the test cases to work as expected.
  */
 TEST_IFX(digitalio_single_internal, test_digitalio_read_write_input_pullup)
 {
+    pinMode(TEST_DIGITALIO_OUTPUT, OUTPUT);
+    pinMode(TEST_DIGITALIO_INPUT, INPUT_PULLUP);
+
     digitalWrite(TEST_DIGITALIO_OUTPUT, HIGH);
-    TEST_ASSERT_EQUAL_MESSAGE(HIGH, digitalRead(TEST_DIGITALIO_INPUT_1), "Input Pin should be set to HIGH");
+    TEST_ASSERT_EQUAL_MESSAGE(HIGH, digitalRead(TEST_DIGITALIO_INPUT), "Input Pin should be set to HIGH");
     digitalWrite(TEST_DIGITALIO_OUTPUT, LOW);
-    TEST_ASSERT_EQUAL_MESSAGE(LOW, digitalRead(TEST_DIGITALIO_INPUT_1), "Input Pin should be set to LOW");
+    TEST_ASSERT_EQUAL_MESSAGE(LOW, digitalRead(TEST_DIGITALIO_INPUT), "Input Pin should be set to LOW");
 }
 
 /**
  * @brief This test is to verify digitalWrite and digitalRead functions when input pin is set to INPUT_PULLDOWN mode.
  * 
- * @note: Assumption is made that TEST_DIGITALIO_OUTPUT is connected to TEST_DIGITALIO_INPUT_1
+ * @note: Assumption is made that TEST_DIGITALIO_OUTPUT is connected to TEST_DIGITALIO_INPUT
  *       for the test cases to work as expected.
  */
 TEST_IFX(digitalio_single_internal, test_digitalio_read_write_input_pulldown) 
 {
+    pinMode(TEST_DIGITALIO_OUTPUT, OUTPUT);
+    pinMode(TEST_DIGITALIO_INPUT, INPUT_PULLDOWN);
+
     digitalWrite(TEST_DIGITALIO_OUTPUT, HIGH);
-    TEST_ASSERT_EQUAL_MESSAGE(HIGH, digitalRead(TEST_DIGITALIO_INPUT_1), "Input Pin should be set to HIGH");
+    TEST_ASSERT_EQUAL_MESSAGE(HIGH, digitalRead(TEST_DIGITALIO_INPUT), "Input Pin should be set to HIGH");
     digitalWrite(TEST_DIGITALIO_OUTPUT, LOW);
-    TEST_ASSERT_EQUAL_MESSAGE(LOW, digitalRead(TEST_DIGITALIO_INPUT_1), "Input Pin should be set to LOW");
+    TEST_ASSERT_EQUAL_MESSAGE(LOW, digitalRead(TEST_DIGITALIO_INPUT), "Input Pin should be set to LOW");
 }
 
 /**
  * @brief This test is to verify digitalWrite and digitalRead functions when output pin is set to OPENDRAIN mode.
  * 
- * @note: Assumption is made that TEST_DIGITALIO_OUTPUT is connected to TEST_DIGITALIO_INPUT_1
+ * @note: Assumption is made that TEST_DIGITALIO_OUTPUT is connected to TEST_DIGITALIO_INPUT
  *       for the test cases to work as expected.
  */
 TEST_IFX(digitalio_single_internal, test_digitalio_read_write_output_opendrain)
 {
     pinMode(TEST_DIGITALIO_OUTPUT, OUTPUT_OPENDRAIN);
-    TEST_ASSERT_EQUAL_MESSAGE(LOW, digitalRead(TEST_DIGITALIO_INPUT_1), "Input Pin should be set to LOW initially");
+    pinMode(TEST_DIGITALIO_INPUT, INPUT);
+
+    TEST_ASSERT_EQUAL_MESSAGE(LOW, digitalRead(TEST_DIGITALIO_INPUT), "Input Pin should be set to LOW initially");
 
     digitalWrite(TEST_DIGITALIO_OUTPUT, HIGH);
-    TEST_ASSERT_EQUAL_MESSAGE(HIGH, digitalRead(TEST_DIGITALIO_INPUT_1), "Input Pin should be set to HIGH");
+    TEST_ASSERT_EQUAL_MESSAGE(HIGH, digitalRead(TEST_DIGITALIO_INPUT), "Input Pin should be set to HIGH");
     digitalWrite(TEST_DIGITALIO_OUTPUT, LOW);
-    TEST_ASSERT_EQUAL_MESSAGE(LOW, digitalRead(TEST_DIGITALIO_INPUT_1), "Input Pin should be set to LOW");
-}
-
-/**
- * @brief This test is to verify input pin is set to INPUT mode correctly.
- * 
- * @note: Assumption is made that TEST_DIGITALIO_INPUT_2 is not connected to any other pin
- */
-TEST_IFX(digitalio_single_internal, test_digitalio_input_mode_default)
-{
-    pinMode(TEST_DIGITALIO_INPUT_2, INPUT);
-    TEST_ASSERT_EQUAL_MESSAGE(LOW, digitalRead(TEST_DIGITALIO_INPUT_1), "Input Pin should read LOW initially");  
-}
-
-/**
- * @brief This test is to verify input pin is set to INPUT_PULLUP mode correctly.
- * 
- * @note: Assumption is made that TEST_DIGITALIO_INPUT_2 is not connected to any other pin
- */
-TEST_IFX(digitalio_single_internal, test_digitalio_input_mode_pullup)
-{
-    pinMode(TEST_DIGITALIO_INPUT_2, INPUT_PULLUP);
-    TEST_ASSERT_EQUAL_MESSAGE(HIGH, digitalRead(TEST_DIGITALIO_INPUT_2), "Input Pin should read HIGH initially due to pull-up"); 
-}
-
-/**
- * @brief This test is to verify input pin is set to INPUT_PULLDOWN mode correctly.
- * 
- * @note: Assumption is made that TEST_DIGITALIO_INPUT_2 is not connected to any other pin
- */
-TEST_IFX(digitalio_single_internal, test_digitalio_input_mode_pulldown)
-{
-    pinMode(TEST_DIGITALIO_INPUT_2, INPUT_PULLDOWN);
-    TEST_ASSERT_EQUAL_MESSAGE(LOW, digitalRead(TEST_DIGITALIO_INPUT_1), "Input Pin should read LOW initially due to pull-down"); 
+    TEST_ASSERT_EQUAL_MESSAGE(LOW, digitalRead(TEST_DIGITALIO_INPUT), "Input Pin should be set to LOW");
 }
 
 /**
@@ -171,7 +146,7 @@ TEST_IFX(digitalio_single_internal, test_digitalRead_invalid_pin) {
  * @brief Test invalid pin mode
 */
 TEST_IFX(digitalio_single_internal, test_invalid_pinmode) {
-    pinMode(TEST_DIGITALIO_INPUT_2, 255);
+    pinMode(TEST_DIGITALIO_INPUT, 255);
     // No assertion as pinMode doesn't return a value, but ensure no crash
 }
 
@@ -184,9 +159,6 @@ static TEST_GROUP_RUNNER(digitalio_single_internal)
     RUN_TEST_CASE(digitalio_single_internal, test_digitalio_read_write_input_pullup);
     RUN_TEST_CASE(digitalio_single_internal, test_digitalio_read_write_input_pulldown);
     RUN_TEST_CASE(digitalio_single_internal, test_digitalio_read_write_output_opendrain);
-    RUN_TEST_CASE(digitalio_single_internal, test_digitalio_input_mode_default);
-    RUN_TEST_CASE(digitalio_single_internal, test_digitalio_input_mode_pullup);
-    RUN_TEST_CASE(digitalio_single_internal, test_digitalio_input_mode_pulldown);
     RUN_TEST_CASE(digitalio_single_internal, test_pinMode_invalid_pin);
     RUN_TEST_CASE(digitalio_single_internal, test_digitalWrite_invalid_pin);
     RUN_TEST_CASE(digitalio_single_internal, test_digitalRead_invalid_pin);

--- a/src/corelibs/interrupts/test_interrupts_single.cpp
+++ b/src/corelibs/interrupts/test_interrupts_single.cpp
@@ -1,0 +1,204 @@
+/* test_interrupts_single.cpp
+ *
+ * This test is used to verify the functionality of the GPIO Interrupts.
+ * TEST_DIGITALIO_OUTPUT pin should be connected to TEST_DIGITALIO_INPUT pin
+ * for the test cases to work as expected.
+ */
+
+#include "test_common_includes.h"
+#include "test_config.h"
+
+// Defines
+#define TRACE_OUTPUT
+
+// Variables
+volatile bool interrupt_triggered = false;
+
+// Method invoked before a test suite is run.
+static void gpio_interrupts_single_suite_setup() {
+    
+}
+
+// Method invoked after a test suite is run.
+static void gpio_interrupts_single_suite_teardown() {
+    
+}
+
+// Test group name
+TEST_GROUP(gpio_interrupts_single);
+TEST_GROUP(gpio_interrupts_single_internal);
+
+/**
+ * @brief Setup method called by Unity before every test in this test group.
+ */
+static TEST_SETUP(gpio_interrupts_single_internal)
+{ 
+    pinMode(TEST_DIGITALIO_OUTPUT, OUTPUT);
+    pinMode(TEST_DIGITALIO_INPUT, INPUT);
+    interrupt_triggered = false;
+}
+
+/**
+ * @brief Tear down method called by Unity after every test in this test group.
+ */
+static TEST_TEAR_DOWN(gpio_interrupts_single_internal) {
+}
+
+/**
+ * @brief Interrupt callback function.
+ */
+void interrupt_callback() {
+    interrupt_triggered = true;
+}
+
+/**
+ * @brief Test attachInterrupt and detachInterrupt with a valid pin at rising edge.
+ */
+TEST_IFX(gpio_interrupts_single_internal, test_attach_interrupt_rising_edge)
+{
+    digitalWrite(TEST_DIGITALIO_OUTPUT, LOW); // initial state
+
+    attachInterrupt(TEST_DIGITALIO_INPUT, interrupt_callback, RISING);
+
+    digitalWrite(TEST_DIGITALIO_OUTPUT, HIGH); // triggers interrupt
+    delay(100);
+    TEST_ASSERT_TRUE_MESSAGE(interrupt_triggered, "Interrupt should be triggered");
+
+    // detach interrupt and test
+    digitalWrite(TEST_DIGITALIO_OUTPUT, LOW); // initial state
+
+    detachInterrupt(TEST_DIGITALIO_INPUT);
+
+    interrupt_triggered = false;
+    digitalWrite(TEST_DIGITALIO_OUTPUT, HIGH);
+    delay(100);
+    TEST_ASSERT_FALSE_MESSAGE(interrupt_triggered, "Interrupt should not be triggered after detach");
+}
+
+/**
+ * @brief Test attachInterrupt and detachInterrupt with a valid pin at falling edge.
+ */
+TEST_IFX(gpio_interrupts_single_internal, test_attach_interrupt_falling_edge)
+{
+    digitalWrite(TEST_DIGITALIO_OUTPUT, HIGH); // initial state
+    attachInterrupt(TEST_DIGITALIO_INPUT, interrupt_callback, FALLING);
+
+    digitalWrite(TEST_DIGITALIO_OUTPUT, LOW); // triggers interrupt
+    delay(100);
+    TEST_ASSERT_TRUE_MESSAGE(interrupt_triggered, "Interrupt should be triggered");
+
+    // detach interrupt and test
+    digitalWrite(TEST_DIGITALIO_OUTPUT, HIGH); // initial state
+
+    detachInterrupt(TEST_DIGITALIO_INPUT);
+
+    interrupt_triggered = false;
+    digitalWrite(TEST_DIGITALIO_OUTPUT, LOW);
+    delay(100);
+    TEST_ASSERT_FALSE_MESSAGE(interrupt_triggered, "Interrupt should not be triggered after detach");
+}
+
+/**
+ * @brief Test attachInterrupt and detachInterrupt with a valid pin at both edge.
+ */
+TEST_IFX(gpio_interrupts_single_internal, test_attach_interrupt_change_edge)
+{
+    digitalWrite(TEST_DIGITALIO_OUTPUT, LOW); // initial state
+
+    attachInterrupt(TEST_DIGITALIO_INPUT, interrupt_callback, CHANGE);
+
+    digitalWrite(TEST_DIGITALIO_OUTPUT, HIGH); // triggers interrupt
+    delay(100);
+    TEST_ASSERT_TRUE_MESSAGE(interrupt_triggered, "Interrupt should be triggered");
+
+    interrupt_triggered = false;
+    digitalWrite(TEST_DIGITALIO_OUTPUT, LOW); // triggers interrupt
+    delay(100);
+    TEST_ASSERT_TRUE_MESSAGE(interrupt_triggered, "Interrupt should be triggered");
+
+    interrupt_triggered = false;
+    digitalWrite(TEST_DIGITALIO_OUTPUT, HIGH); // triggers interrupt
+    delay(100);
+    TEST_ASSERT_TRUE_MESSAGE(interrupt_triggered, "Interrupt should be triggered");
+
+    // detach interrupt and test
+    interrupt_triggered = false;
+    detachInterrupt(TEST_DIGITALIO_INPUT);
+
+    digitalWrite(TEST_DIGITALIO_OUTPUT, HIGH);
+    delay(100);
+    TEST_ASSERT_FALSE_MESSAGE(interrupt_triggered, "Interrupt should not be triggered after detach");
+}
+
+/**
+ * @brief Test attachInterrupt and detachInterrupt with a valid pin at both edge.
+ */
+TEST_IFX(gpio_interrupts_single_internal, test_attach_interrupt_invalid_mode)
+{
+    digitalWrite(TEST_DIGITALIO_OUTPUT, LOW); // initial state
+
+    attachInterrupt(TEST_DIGITALIO_INPUT, interrupt_callback, (PinStatus) 255);
+
+    digitalWrite(TEST_DIGITALIO_OUTPUT, HIGH); 
+    delay(100);
+    digitalWrite(TEST_DIGITALIO_OUTPUT, LOW); 
+    delay(100);
+    TEST_ASSERT_FALSE_MESSAGE(interrupt_triggered, "Interrupt should not be triggered when invalid mode is set");
+
+}
+
+/**
+ * @brief Test attachInterrupt with an invalid pin.
+ */
+TEST_IFX(gpio_interrupts_single_internal, test_attach_interrupt_invalid_pin)
+{
+    digitalWrite(TEST_DIGITALIO_OUTPUT, LOW);
+
+    attachInterrupt(255, interrupt_callback, RISING); // Use an invalid pin number
+
+    // Trigger the interrupt by writing HIGH to the output pin
+    digitalWrite(TEST_DIGITALIO_OUTPUT, HIGH);
+
+    // Small delay to ensure the interrupt is processed
+    delay(100);
+
+    TEST_ASSERT_FALSE_MESSAGE(interrupt_triggered, "Interrupt should not be triggered for invalid pin");
+}
+
+
+/**
+ * @brief Test digitalPinToInterrupt function.
+ */
+TEST_IFX(gpio_interrupts_single_internal, test_digital_pin_to_interrupt)
+{
+    int interrupt_number = digitalPinToInterrupt(TEST_DIGITALIO_INPUT);
+    TEST_ASSERT_EQUAL_MESSAGE(TEST_DIGITALIO_INPUT, interrupt_number, "Interrupt number should match the input pin");
+
+    int invalid_interrupt_number = digitalPinToInterrupt(255); // Use an invalid pin number
+    TEST_ASSERT_EQUAL_MESSAGE(-1, invalid_interrupt_number, "Interrupt number should be -1 for invalid pin");
+}
+
+/**
+ * @brief Test group runner to run all test cases in this group.
+ */
+static TEST_GROUP_RUNNER(gpio_interrupts_single_internal)
+{
+    RUN_TEST_CASE(gpio_interrupts_single_internal, test_attach_interrupt_rising_edge);
+    RUN_TEST_CASE(gpio_interrupts_single_internal, test_attach_interrupt_falling_edge);
+    RUN_TEST_CASE(gpio_interrupts_single_internal, test_attach_interrupt_change_edge);
+    RUN_TEST_CASE(gpio_interrupts_single_internal, test_attach_interrupt_invalid_mode);
+    RUN_TEST_CASE(gpio_interrupts_single_internal, test_attach_interrupt_invalid_pin);
+    RUN_TEST_CASE(gpio_interrupts_single_internal, test_digital_pin_to_interrupt);
+}
+
+/**
+ * @brief Bundle all tests to be executed for this test group.
+ */
+TEST_GROUP_RUNNER(gpio_interrupts_single)
+{
+    gpio_interrupts_single_suite_setup();
+
+    RUN_TEST_GROUP(gpio_interrupts_single_internal);
+
+    gpio_interrupts_single_suite_teardown();
+}

--- a/src/test_main.ino
+++ b/src/test_main.ino
@@ -22,6 +22,12 @@ void RunAllTests(void)
 
 #endif
 
+#ifdef TEST_INTERRUPTS_SINGLE
+
+    RUN_TEST_GROUP(gpio_interrupts_single);
+
+#endif
+
 #ifdef TEST_UART_CONNECTED2_TX
 
     RUN_TEST_GROUP(uart_connected2_tx);


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Added GPIO interrupt tests
Remove pin mode pullup and pulldown tests which checks what is the initial value because we need to run each of these test with a separate pin. So I think we can just remove it. Anyways we run the normal tests in every pin mode.