### PR TITLE
Wifi begin tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,10 @@ test_wire_connected1_pingpong: TESTS=-DTEST_WIRE_CONNECTED1_PINGPONG
 test_wire_connected2_masterpingpong: TESTS=-DTEST_WIRE_CONNECTED2_MASTERPINGPONG
 test_wire_connected2_slavepingpong:  TESTS=-DTEST_WIRE_CONNECTED2_SLAVEPINGPONG
 
+## WiFi tests targets
+test_wifi_sta: TESTS=-DTEST_WIFI_STA
+test_wifi_ap: TESTS=-DTEST_WIFI_AP
+
 # Arduino-cli commands
 
 # For WSL and Windows :

--- a/src/corelibs/wifi/test_wifi_ap.cpp
+++ b/src/corelibs/wifi/test_wifi_ap.cpp
@@ -1,0 +1,26 @@
+#include "test_common_includes.h"
+
+#include <WiFi.h>
+
+TEST_GROUP(wifi_ap);
+
+static TEST_SETUP(wifi_ap) {
+}
+
+static TEST_TEAR_DOWN(wifi_ap) {
+    WiFi.end();
+}
+
+TEST(wifi_ap, begin_ap) {
+    int result = WiFi.beginAP("arduino-wifi-ap", "wifi-ap-password", 1);
+    TEST_ASSERT_EQUAL_INT(WL_AP_CONNECTED, result);
+
+    /* Wait forever for now. */
+    while(true) {};
+}
+
+TEST_GROUP_RUNNER(wifi_ap) {
+    RUN_TEST_CASE(wifi_ap, begin_ap);
+}
+
+

--- a/src/corelibs/wifi/test_wifi_sta.cpp
+++ b/src/corelibs/wifi/test_wifi_sta.cpp
@@ -1,0 +1,26 @@
+#include "test_common_includes.h"
+
+#include <WiFi.h>
+
+TEST_GROUP(wifi_sta);
+
+static TEST_SETUP(wifi_sta) {
+}
+
+static TEST_TEAR_DOWN(wifi_sta) {
+    WiFi.end();
+}
+
+TEST(wifi_sta, connect_to_ap) {
+    /* This AP is created by the test_wifi_ap.
+       Currently the test tools does provide a way to and synch multitest. 
+       It has only be validated manually. */
+    int result = WiFi.begin("arduino-wifi-ap", "wifi-ap-password");
+    TEST_ASSERT_EQUAL_INT(WL_CONNECTED, result);
+}
+
+TEST_GROUP_RUNNER(wifi_sta) {
+    RUN_TEST_CASE(wifi_sta, connect_to_ap);
+}
+
+

--- a/src/test_main.ino
+++ b/src/test_main.ino
@@ -86,17 +86,27 @@ void RunAllTests(void)
 
 #endif
 
+#ifdef TEST_WIFI_STA
+
+    RUN_TEST_GROUP(wifi_sta);
+
+#endif
+
+#ifdef TEST_WIFI_AP
+
+    RUN_TEST_GROUP(wifi_ap);
+
+#endif
+
 }
 
 
-//
 void setup() {
     Serial.begin(115200);
     Serial.println("setup done.");
 }
 
 
-//
 void loop() {
     Serial.println("\n");
 


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Added initial setup for WiFi test including manually evaluated begin() and beginAP() functions.
This is just the first of a series of PR which will conclude with the WiFi() class tests. 

The multi-test feature needs to be developed and enabled for integration on HIL. But this is out of the scope of this task. 