### PR TITLE
Add pwm tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ test_time_single: TESTS=-DTEST_TIME_SINGLE
 test_digitalio_single: TESTS=-DTEST_DIGITALIO_SINGLE
 
 # Analog IO tests targets
-test_analogio_single: TESTS=-DTEST_ANALOGIO_SINGLE
+test_analogio_adc: TESTS=-DTEST_ANALOGIO_ADC
 test_analogio_pwm: TESTS=-DTEST_ANALOGIO_PWM
 
 # GPIO Interrupts tests targets
@@ -119,7 +119,7 @@ else
 						--build-property "compiler.c.extra_flags=\"-DUNITY_INCLUDE_CONFIG_H=1\"" \
 						--build-property compiler.cpp.extra_flags="$(TESTS)" \
 						--export-binaries \
-					build --verbose
+					build
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,10 @@ test_time_single: TESTS=-DTEST_TIME_SINGLE
 
 # Digital IO tests targets
 test_digitalio_single: TESTS=-DTEST_DIGITALIO_SINGLE
+
+# Analog IO tests targets
 test_analogio_single: TESTS=-DTEST_ANALOGIO_SINGLE
+test_analogio_pwm: TESTS=-DTEST_ANALOGIO_PWM
 
 # GPIO Interrupts tests targets
 test_interrupts_single: TESTS=-DTEST_INTERRUPTS_SINGLE
@@ -116,7 +119,7 @@ else
 						--build-property "compiler.c.extra_flags=\"-DUNITY_INCLUDE_CONFIG_H=1\"" \
 						--build-property compiler.cpp.extra_flags="$(TESTS)" \
 						--export-binaries \
-					build
+					build --verbose
 endif
 
 

--- a/src/corelibs/analogio/test_analogio_adc.cpp
+++ b/src/corelibs/analogio/test_analogio_adc.cpp
@@ -1,5 +1,5 @@
 /**
- * @brief test_analogio_single.cpp
+ * @brief test_analogio_adc.cpp
  *
  * @details This test is used to verify the functionality of the Analog IO module.
  * only one board is needed with 
@@ -52,7 +52,7 @@ static bool validate_adc_raw_value(int expected_value, int actual_value) {
 /**
  * @brief Suite setup function, runs before test suite execution begins.
  */
-static void analogio_single_suite_setup() {
+static void analogio_adc_suite_setup() {
     
 }
 
@@ -60,23 +60,23 @@ static void analogio_single_suite_setup() {
 /**
  * @brief Suite teardown function, runs after test suite execution is complete.
  */
-static void analogio_single_suite_teardown() {
+static void analogio_adc_suite_teardown() {
     
 }
 
 // Define test group name
-TEST_GROUP(analogio_single);
+TEST_GROUP(analogio_adc);
 
 /**
  * @brief Setup method called by Unity before every test in this test group.
  */
-static TEST_SETUP(analogio_single) { 
+static TEST_SETUP(analogio_adc) { 
 }
 
 /**
  * @brief Tear down method called by Unity after every test in this test group.
  */
-static TEST_TEAR_DOWN(analogio_single) {
+static TEST_TEAR_DOWN(analogio_adc) {
 }
 
 #ifdef TEST_PIN_ANALOG_IO_VREF 
@@ -84,7 +84,7 @@ static TEST_TEAR_DOWN(analogio_single) {
 /**
  * @brief Verify ADC value for the DEFAULT volatage reference on the pin that is connected to VDDA
  */
-TEST_IFX(analogio_single, test_adc_read_default_vdda_vref_pin)
+TEST_IFX(analogio_adc, test_adc_read_default_vdda_vref_pin)
 {
     analogReference(DEFAULT); 
     int adc_value = analogRead(TEST_PIN_ANALOG_IO_VREF);
@@ -99,7 +99,7 @@ TEST_IFX(analogio_single, test_adc_read_default_vdda_vref_pin)
 /**
  * @brief Verify ADC value for the DEFAULT volatage reference on the pin that is connected to voltage divider.
  */
-TEST_IFX(analogio_single, test_adc_read_default_vdda_divider_pin)
+TEST_IFX(analogio_adc, test_adc_read_default_vdda_divider_pin)
 {
     analogReference(DEFAULT); // Configure reference to VDDA
     int adc_value = analogRead(TEST_PIN_ANALOG_IO_DIVIDER);
@@ -114,7 +114,7 @@ TEST_IFX(analogio_single, test_adc_read_default_vdda_divider_pin)
 /**
  * @brief Verify ADC value for the DEFAULT volatage reference on the pin that is connected to ground.
  */
-TEST_IFX(analogio_single, test_adc_read_default_gnd_pin)
+TEST_IFX(analogio_adc, test_adc_read_default_gnd_pin)
 {
     analogReference(DEFAULT); 
     int adc_value = analogRead(TEST_PIN_ANALOG_IO_GND);
@@ -128,21 +128,21 @@ TEST_IFX(analogio_single, test_adc_read_default_gnd_pin)
 /**
  * @brief Bundle all tests to be executed for this test group.
  */
-TEST_GROUP_RUNNER(analogio_single)
+TEST_GROUP_RUNNER(analogio_adc)
 {
-    analogio_single_suite_setup();
+    analogio_adc_suite_setup();
 
 #ifdef TEST_PIN_ANALOG_IO_VREF 
-    RUN_TEST_CASE(analogio_single, test_adc_read_default_vdda_vref_pin);
+    RUN_TEST_CASE(analogio_adc, test_adc_read_default_vdda_vref_pin);
 #endif
 
 #ifdef TEST_PIN_ANALOG_IO_DIVIDER
-    RUN_TEST_CASE(analogio_single, test_adc_read_default_vdda_divider_pin);
+    RUN_TEST_CASE(analogio_adc, test_adc_read_default_vdda_divider_pin);
 #endif
 
 #ifdef TEST_PIN_ANALOG_IO_GND
-    RUN_TEST_CASE(analogio_single, test_adc_read_default_gnd_pin);
+    RUN_TEST_CASE(analogio_adc, test_adc_read_default_gnd_pin);
 #endif
 
-    analogio_single_suite_teardown();
+    analogio_adc_suite_teardown();
 }

--- a/src/corelibs/analogio/test_analogio_pwm.cpp
+++ b/src/corelibs/analogio/test_analogio_pwm.cpp
@@ -1,0 +1,258 @@
+/**
+ * @brief test_analogio_pwm.cpp
+ *
+ * @details This test is used to verify the functionality of the Analog IO module.
+ * only one board is needed with PWM_PIN_OUTPUT (TEST_PIN_DIGITAL_IO_OUTPUT) pin connected to 
+ * PWM_PIN_FEEDBACK (TEST_PIN_DIGITAL_IO_INPUT) pin for the test cases to work as expected.
+ * 
+ */
+
+// std includes
+
+// test includes
+#include "test_common_includes.h"
+#include "test_config.h"
+
+// project includes
+
+// defines
+#define TRACE_OUTPUT
+#define TOLERANCE_DUTY_CYCLE 5.0f           // 5% tolerance for duty cycle
+#define TOLERANCE_FREQUENCY 10.0f           // 10 Hz tolerance for frequency
+#define PWM_PIN_OUTPUT      TEST_PIN_DIGITAL_IO_OUTPUT
+#define PWM_PIN_FEEDBACK    TEST_PIN_DIGITAL_IO_INPUT
+
+volatile uint32_t start_time = 0;            // Timestamp of the last rising edge
+volatile uint32_t high_time = 0;             // Duration of the HIGH period
+volatile uint32_t low_time = 0;              // Duration of the LOW period
+volatile bool high_measured = false;         // Flag to indicate a full PWM cycle has been measured
+
+// variables
+volatile float measured_duty_cycle_percentage = 0; 
+volatile uint32_t measured_frequency_hz = 0; 
+
+/**
+ * @brief Interrupt handler for the PWM feedback pin.
+ * This function is triggered on both rising and falling edges of the PWM signal.
+ */
+void feedback_interrupt_handler() {
+    uint32_t current_time = micros(); // Get the current timestamp
+
+    // Check the current state of the feedback pin
+    if (digitalRead(TEST_PIN_DIGITAL_IO_INPUT) == HIGH) {
+        // Rising edge detected
+        if (start_time > 0) { // Ensure this is not the first edge
+            low_time = current_time - start_time; // Measure LOW time (previous cycle)
+        }
+        start_time = current_time; // Update start_time for HIGH period
+    } else {
+        // Falling edge detected
+        high_time = current_time - start_time; // Measure HIGH time
+        start_time = current_time;             // Update start_time for LOW period
+
+        // Indicate that we have captured a full PWM cycle (HIGH + LOW)
+        high_measured = true;
+    }
+}
+
+/**
+ * @brief Function to process the measured timing and calculate duty cycle and frequency.
+ */
+void feedback_measurement_handler() {
+    uint32_t t_period;
+
+    // Wait until a full PWM cycle has been measured
+    while (!high_measured);
+
+    // Disable interrupts temporarily to avoid race conditions
+    noInterrupts();
+
+    // Calculate the total period (HIGH + LOW)
+    t_period = high_time + low_time;
+
+    // Calculate duty cycle and frequency
+    measured_duty_cycle_percentage = ((float)high_time / t_period) * 100.0f;
+    measured_frequency_hz = 1000000 / t_period; // Convert period to frequency
+
+    // Reset the measurement flag
+    high_measured = false;
+
+    // Re-enable interrupts
+    interrupts();
+
+}
+
+/**
+ * @brief Suite setup function, runs before test suite execution begins.
+ */
+static void analogio_pwm_suite_setup() {
+    pinMode(PWM_PIN_FEEDBACK, INPUT);
+    attachInterrupt(digitalPinToInterrupt(PWM_PIN_FEEDBACK), feedback_interrupt_handler, CHANGE);
+}
+
+
+/**
+ * @brief Suite teardown function, runs after test suite execution is complete.
+ */
+static void analogio_pwm_suite_teardown() {
+    
+}
+
+// Define test group name
+TEST_GROUP(analogio_pwm);
+
+/**
+ * @brief Setup method called by Unity before every test in this test group.
+ */
+static TEST_SETUP(analogio_pwm) { 
+    interrupts();
+    // Reset the measurement variables
+    start_time = 0;
+    high_time = 0;
+    low_time = 0;
+    high_measured = false;
+}
+
+/**
+ * @brief Tear down method called by Unity after every test in this test group.
+ */
+static TEST_TEAR_DOWN(analogio_pwm) {
+    noInterrupts();
+}
+
+/**
+ * @brief Verify PWM duty cycle for various percentages (25%, 50%, 75%) with default 8-bit resolution.
+ */
+TEST_IFX(analogio_pwm, test_analog_write_pwm_8_bit_resolution)
+{
+    analogWriteResolution(5); // Any value lesser than or equal to 8 will be considered as 8-bit resolution
+
+    // Array of expected duty cycle percentages and their corresponding analogWrite values (8-bit resolution, 0 to 255)
+    const float expected_duty_cycles[] = {25.0f, 50.0f, 75.0f};
+    const uint8_t analog_write_values[] = {64, 127, 191};
+
+    for (size_t i = 0; i < sizeof(expected_duty_cycles) / sizeof(expected_duty_cycles[0]); i++) {
+        analogWrite(PWM_PIN_OUTPUT, analog_write_values[i]);
+
+        delay(1000); // Wait for the signal to stabilize
+
+        feedback_measurement_handler();
+
+        TEST_ASSERT_FLOAT_WITHIN(TOLERANCE_DUTY_CYCLE, expected_duty_cycles[i], measured_duty_cycle_percentage);
+        TEST_ASSERT_FLOAT_WITHIN(TOLERANCE_FREQUENCY, PWM_FREQUENCY_HZ, measured_frequency_hz);
+    } 
+}
+
+/**
+ * @brief Verify PWM duty cycle for various percentages (25%, 50%, 75%) with 10-bit resolution.
+ */
+TEST_IFX(analogio_pwm, test_analog_write_pwm_10_bit_resolution)
+{
+    analogWriteResolution(10); 
+
+    // Array of expected duty cycle percentages and their corresponding analogWrite values (10-bit resolution, 0 to 1023)
+    const float expected_duty_cycles[] = {25.0f, 50.0f, 75.0f};
+    const uint16_t analog_write_values[] = {256, 511, 767};
+
+    for (size_t i = 0; i < sizeof(expected_duty_cycles) / sizeof(expected_duty_cycles[0]); i++) {
+        analogWrite(PWM_PIN_OUTPUT, analog_write_values[i]);
+
+        delay(1000); // Wait for the signal to stabilize
+
+        feedback_measurement_handler();
+
+        TEST_ASSERT_FLOAT_WITHIN(TOLERANCE_DUTY_CYCLE, expected_duty_cycles[i], measured_duty_cycle_percentage);
+        TEST_ASSERT_FLOAT_WITHIN(TOLERANCE_FREQUENCY, PWM_FREQUENCY_HZ, measured_frequency_hz);
+    } 
+}
+
+/**
+ * @brief Verify PWM duty cycle for various percentages (25%, 50%, 75%) with 12-bit resolution.
+ */
+TEST_IFX(analogio_pwm, test_analog_write_pwm_12_bit_resolution)
+{
+    analogWriteResolution(12); 
+
+    // Array of expected duty cycle percentages and their corresponding analogWrite values (12-bit resolution, 0 to 4095)
+    const float expected_duty_cycles[] = {25.0f, 50.0f, 75.0f};
+    const uint16_t analog_write_values[] = {1024, 2047, 3071};
+
+    for (size_t i = 0; i < sizeof(expected_duty_cycles) / sizeof(expected_duty_cycles[0]); i++) {
+        analogWrite(PWM_PIN_OUTPUT, analog_write_values[i]);
+
+        delay(1000); // Wait for the signal to stabilize
+
+        feedback_measurement_handler();
+
+        TEST_ASSERT_FLOAT_WITHIN(TOLERANCE_DUTY_CYCLE, expected_duty_cycles[i], measured_duty_cycle_percentage);
+        TEST_ASSERT_FLOAT_WITHIN(TOLERANCE_FREQUENCY, PWM_FREQUENCY_HZ, measured_frequency_hz);
+    } 
+}
+
+/**
+ * @brief Verify PWM duty cycle for various percentages (25%, 50%, 75%) with 16-bit resolution.
+ */
+TEST_IFX(analogio_pwm, test_analog_write_pwm_16_bit_resolution)
+{
+    analogWriteResolution(20); // Any value greater than 12 will be considered as 16-bit resolution
+
+    // Array of expected duty cycle percentages and their corresponding analogWrite values (16-bit resolution, 0 to 65535)
+    const float expected_duty_cycles[] = {25.0f, 50.0f, 75.0f};
+    const uint16_t analog_write_values[] = {16384, 32767, 49151};
+
+    for (size_t i = 0; i < sizeof(expected_duty_cycles) / sizeof(expected_duty_cycles[0]); i++) {
+        analogWrite(PWM_PIN_OUTPUT, analog_write_values[i]);
+
+        delay(1000); // Wait for the signal to stabilize
+
+        feedback_measurement_handler();
+
+        TEST_ASSERT_FLOAT_WITHIN(TOLERANCE_DUTY_CYCLE, expected_duty_cycles[i], measured_duty_cycle_percentage);
+        TEST_ASSERT_FLOAT_WITHIN(TOLERANCE_FREQUENCY, PWM_FREQUENCY_HZ, measured_frequency_hz);
+    } 
+}
+
+/**
+ * @brief Verify PWM 100% duty cycle.
+ */
+TEST_IFX(analogio_pwm, test_analog_write_pwm_100_percentage_dutycycle)
+{
+    analogWriteResolution(16);
+    analogWrite(PWM_PIN_OUTPUT, 65535);  
+    delay(1000); // Wait for the signal to stabilize
+
+    TEST_ASSERT_EQUAL_MESSAGE(HIGH, digitalRead(PWM_PIN_FEEDBACK), "PWM output should be HIGH when 100 percentage duty cycle is set");
+    // Check once again if the PWM pin is still HIGH
+    TEST_ASSERT_EQUAL_MESSAGE(HIGH, digitalRead(PWM_PIN_FEEDBACK), "PWM output should be HIGH when 100 percentage duty cycle is set");
+}
+
+/**
+ * @brief Verify PWM 0% duty cycle.
+ */
+TEST_IFX(analogio_pwm, test_analog_write_pwm_0_percentage_dutycycle)
+{
+    analogWriteResolution(8);
+    analogWrite(PWM_PIN_OUTPUT, 0);  
+    delay(1000); // Wait for the signal to stabilize
+
+    TEST_ASSERT_EQUAL_MESSAGE(LOW, digitalRead(PWM_PIN_FEEDBACK), "PWM output should be LOW when 0 percentage duty cycle is set");
+    // Check once again if the PWM pin is still LOW
+    TEST_ASSERT_EQUAL_MESSAGE(LOW, digitalRead(PWM_PIN_FEEDBACK), "PWM output should be LOW when 0 percentage duty cycle is set");
+}
+
+/**
+ * @brief Bundle all tests to be executed for this test group.
+ */
+TEST_GROUP_RUNNER(analogio_pwm)
+{
+    analogio_pwm_suite_setup();
+
+    RUN_TEST_CASE(analogio_pwm, test_analog_write_pwm_8_bit_resolution);
+    RUN_TEST_CASE(analogio_pwm, test_analog_write_pwm_10_bit_resolution);
+    RUN_TEST_CASE(analogio_pwm, test_analog_write_pwm_12_bit_resolution);
+    RUN_TEST_CASE(analogio_pwm, test_analog_write_pwm_16_bit_resolution);
+    RUN_TEST_CASE(analogio_pwm, test_analog_write_pwm_100_percentage_dutycycle);
+    RUN_TEST_CASE(analogio_pwm, test_analog_write_pwm_0_percentage_dutycycle);
+
+    analogio_pwm_suite_teardown();
+}

--- a/src/corelibs/analogio/test_analogio_single.cpp
+++ b/src/corelibs/analogio/test_analogio_single.cpp
@@ -4,9 +4,9 @@
  * @details This test is used to verify the functionality of the Analog IO module.
  * only one board is needed with 
  * 
- * TEST_ANALOG_IO_VREF pin connected to VDDA,
- * TEST_ANALOG_IO_DIVIDER pin connected to voltage divider,
- * TEST_ADC_PIN_GND pin connected to Ground.
+ * TEST_PIN_ANALOG_IO_VREF pin connected to VDDA,
+ * TEST_PIN_ANALOG_IO_DIVIDER pin connected to voltage divider,
+ * TEST_PIN_ANALOG_IO_GND pin connected to Ground.
  * Depending on the pins availability, the test can be run on any board.
  * 
  * 
@@ -16,13 +16,11 @@
  *      |
  *      [R1]   <-- Resistor R1
  *      |
- *      +-------> A1 (Mid-Point connected to Analog Input pin TEST_ANALOG_IO_DIVIDER)
+ *      +-------> A1 (Mid-Point connected to Analog Input pin TEST_PIN_ANALOG_IO_DIVIDER)
  *      |
  *      [R2]   <-- Resistor R2
  *      |
  *      GND (0V)
- * 
- * @note: The test cases are designed to work with the assumption that the VDDA and RESOLUTION values are set in test_config.h.
  * 
  */
 
@@ -81,7 +79,7 @@ static TEST_SETUP(analogio_single) {
 static TEST_TEAR_DOWN(analogio_single) {
 }
 
-#ifdef TEST_ANALOG_IO_VREF 
+#ifdef TEST_PIN_ANALOG_IO_VREF 
 
 /**
  * @brief Verify ADC value for the DEFAULT volatage reference on the pin that is connected to VDDA
@@ -89,14 +87,14 @@ static TEST_TEAR_DOWN(analogio_single) {
 TEST_IFX(analogio_single, test_adc_read_default_vdda_vref_pin)
 {
     analogReference(DEFAULT); 
-    int adc_value = analogRead(TEST_ANALOG_IO_VREF);
-    int expected_value = RESOLUTION;
+    int adc_value = analogRead(TEST_PIN_ANALOG_IO_VREF);
+    int expected_value = ADC_RESOLUTION;
     TEST_ASSERT_TRUE_MESSAGE(validate_adc_raw_value(expected_value, adc_value), "ADC value is not within the expected range");
 }
 
-#endif // TEST_ANALOG_IO_VREF
+#endif // TEST_PIN_ANALOG_IO_VREF
 
-#ifdef TEST_ANALOG_IO_DIVIDER 
+#ifdef TEST_PIN_ANALOG_IO_DIVIDER 
 
 /**
  * @brief Verify ADC value for the DEFAULT volatage reference on the pin that is connected to voltage divider.
@@ -104,14 +102,14 @@ TEST_IFX(analogio_single, test_adc_read_default_vdda_vref_pin)
 TEST_IFX(analogio_single, test_adc_read_default_vdda_divider_pin)
 {
     analogReference(DEFAULT); // Configure reference to VDDA
-    int adc_value = analogRead(TEST_ANALOG_IO_DIVIDER);
-    int expected_value = RESOLUTION / 2;
+    int adc_value = analogRead(TEST_PIN_ANALOG_IO_DIVIDER);
+    int expected_value = ADC_RESOLUTION / 2;
     TEST_ASSERT_TRUE_MESSAGE(validate_adc_raw_value(expected_value, adc_value), "ADC value is not within the expected range");
 }
 
-#endif // TEST_ANALOG_IO_DIVIDER
+#endif // TEST_PIN_ANALOG_IO_DIVIDER
 
-#ifdef TEST_ADC_PIN_GND 
+#ifdef TEST_PIN_ANALOG_IO_GND 
 
 /**
  * @brief Verify ADC value for the DEFAULT volatage reference on the pin that is connected to ground.
@@ -119,12 +117,12 @@ TEST_IFX(analogio_single, test_adc_read_default_vdda_divider_pin)
 TEST_IFX(analogio_single, test_adc_read_default_gnd_pin)
 {
     analogReference(DEFAULT); 
-    int adc_value = analogRead(TEST_ADC_PIN_GND);
+    int adc_value = analogRead(TEST_PIN_ANALOG_IO_GND);
     int expected_value = 0;
     TEST_ASSERT_TRUE_MESSAGE(validate_adc_raw_value(expected_value, adc_value), "ADC value is not within the expected range");
 }
 
-#endif // TEST_ADC_PIN_GND 
+#endif // TEST_PIN_ANALOG_IO_GND 
 
 
 /**
@@ -134,15 +132,15 @@ TEST_GROUP_RUNNER(analogio_single)
 {
     analogio_single_suite_setup();
 
-#ifdef TEST_ANALOG_IO_VREF 
+#ifdef TEST_PIN_ANALOG_IO_VREF 
     RUN_TEST_CASE(analogio_single, test_adc_read_default_vdda_vref_pin);
 #endif
 
-#ifdef TEST_ANALOG_IO_DIVIDER
+#ifdef TEST_PIN_ANALOG_IO_DIVIDER
     RUN_TEST_CASE(analogio_single, test_adc_read_default_vdda_divider_pin);
 #endif
 
-#ifdef TEST_ADC_PIN_GND
+#ifdef TEST_PIN_ANALOG_IO_GND
     RUN_TEST_CASE(analogio_single, test_adc_read_default_gnd_pin);
 #endif
 

--- a/src/corelibs/digitalio/test_digitalio_single.cpp
+++ b/src/corelibs/digitalio/test_digitalio_single.cpp
@@ -1,8 +1,8 @@
 /* test_digitalio_single.cpp
  *
  * This test is used to verify the functionality of the Digital IO module.
- * only one board is needed with TEST_DIGITALIO_OUTPUT pin connected to 
- * TEST_DIGITALIO_INPUT pin for the test cases to work as expected.
+ * only one board is needed with TEST_PIN_DIGITAL_IO_OUTPUT pin connected to 
+ * TEST_PIN_DIGITAL_IO_INPUT pin for the test cases to work as expected.
  */
 
 // std includes
@@ -52,71 +52,71 @@ static TEST_TEAR_DOWN(digitalio_single_internal) {
 /**
  * @brief This test is to verify digitalWrite and digitalRead functions when input pin is set to INPUT mode.
  * 
- * @note: Assumption is made that TEST_DIGITALIO_OUTPUT is connected to TEST_DIGITALIO_INPUT
+ * @note: Assumption is made that TEST_PIN_DIGITAL_IO_OUTPUT is connected to TEST_PIN_DIGITAL_IO_INPUT
  *       for the test cases to work as expected.
  */
 TEST_IFX(digitalio_single_internal, test_digitalio_read_write_input_normal)
 {
-    pinMode(TEST_DIGITALIO_OUTPUT, OUTPUT);
-    pinMode(TEST_DIGITALIO_INPUT, INPUT);
+    pinMode(TEST_PIN_DIGITAL_IO_OUTPUT, OUTPUT);
+    pinMode(TEST_PIN_DIGITAL_IO_INPUT, INPUT);
 
-    digitalWrite(TEST_DIGITALIO_OUTPUT, HIGH);
-    TEST_ASSERT_EQUAL_MESSAGE(HIGH, digitalRead(TEST_DIGITALIO_INPUT), "Input Pin should be set to HIGH");
-    digitalWrite(TEST_DIGITALIO_OUTPUT, LOW);
-    TEST_ASSERT_EQUAL_MESSAGE(LOW, digitalRead(TEST_DIGITALIO_INPUT), "Input Pin should be set to LOW");
+    digitalWrite(TEST_PIN_DIGITAL_IO_OUTPUT, HIGH);
+    TEST_ASSERT_EQUAL_MESSAGE(HIGH, digitalRead(TEST_PIN_DIGITAL_IO_INPUT), "Input Pin should be set to HIGH");
+    digitalWrite(TEST_PIN_DIGITAL_IO_OUTPUT, LOW);
+    TEST_ASSERT_EQUAL_MESSAGE(LOW, digitalRead(TEST_PIN_DIGITAL_IO_INPUT), "Input Pin should be set to LOW");
 }
 
 /**
  * @brief This test is to verify digitalWrite and digitalRead functions when input pin is set to INPUT_PULLUP mode.
  * 
- * @note: Assumption is made that TEST_DIGITALIO_OUTPUT is connected to TEST_DIGITALIO_INPUT
+ * @note: Assumption is made that TEST_PIN_DIGITAL_IO_OUTPUT is connected to TEST_PIN_DIGITAL_IO_INPUT
  *       for the test cases to work as expected.
  */
 TEST_IFX(digitalio_single_internal, test_digitalio_read_write_input_pullup)
 {
-    pinMode(TEST_DIGITALIO_OUTPUT, OUTPUT);
-    pinMode(TEST_DIGITALIO_INPUT, INPUT_PULLUP);
+    pinMode(TEST_PIN_DIGITAL_IO_OUTPUT, OUTPUT);
+    pinMode(TEST_PIN_DIGITAL_IO_INPUT, INPUT_PULLUP);
 
-    digitalWrite(TEST_DIGITALIO_OUTPUT, HIGH);
-    TEST_ASSERT_EQUAL_MESSAGE(HIGH, digitalRead(TEST_DIGITALIO_INPUT), "Input Pin should be set to HIGH");
-    digitalWrite(TEST_DIGITALIO_OUTPUT, LOW);
-    TEST_ASSERT_EQUAL_MESSAGE(LOW, digitalRead(TEST_DIGITALIO_INPUT), "Input Pin should be set to LOW");
+    digitalWrite(TEST_PIN_DIGITAL_IO_OUTPUT, HIGH);
+    TEST_ASSERT_EQUAL_MESSAGE(HIGH, digitalRead(TEST_PIN_DIGITAL_IO_INPUT), "Input Pin should be set to HIGH");
+    digitalWrite(TEST_PIN_DIGITAL_IO_OUTPUT, LOW);
+    TEST_ASSERT_EQUAL_MESSAGE(LOW, digitalRead(TEST_PIN_DIGITAL_IO_INPUT), "Input Pin should be set to LOW");
 }
 
 /**
  * @brief This test is to verify digitalWrite and digitalRead functions when input pin is set to INPUT_PULLDOWN mode.
  * 
- * @note: Assumption is made that TEST_DIGITALIO_OUTPUT is connected to TEST_DIGITALIO_INPUT
+ * @note: Assumption is made that TEST_PIN_DIGITAL_IO_OUTPUT is connected to TEST_PIN_DIGITAL_IO_INPUT
  *       for the test cases to work as expected.
  */
 TEST_IFX(digitalio_single_internal, test_digitalio_read_write_input_pulldown) 
 {
-    pinMode(TEST_DIGITALIO_OUTPUT, OUTPUT);
-    pinMode(TEST_DIGITALIO_INPUT, INPUT_PULLDOWN);
+    pinMode(TEST_PIN_DIGITAL_IO_OUTPUT, OUTPUT);
+    pinMode(TEST_PIN_DIGITAL_IO_INPUT, INPUT_PULLDOWN);
 
-    digitalWrite(TEST_DIGITALIO_OUTPUT, HIGH);
-    TEST_ASSERT_EQUAL_MESSAGE(HIGH, digitalRead(TEST_DIGITALIO_INPUT), "Input Pin should be set to HIGH");
-    digitalWrite(TEST_DIGITALIO_OUTPUT, LOW);
-    TEST_ASSERT_EQUAL_MESSAGE(LOW, digitalRead(TEST_DIGITALIO_INPUT), "Input Pin should be set to LOW");
+    digitalWrite(TEST_PIN_DIGITAL_IO_OUTPUT, HIGH);
+    TEST_ASSERT_EQUAL_MESSAGE(HIGH, digitalRead(TEST_PIN_DIGITAL_IO_INPUT), "Input Pin should be set to HIGH");
+    digitalWrite(TEST_PIN_DIGITAL_IO_OUTPUT, LOW);
+    TEST_ASSERT_EQUAL_MESSAGE(LOW, digitalRead(TEST_PIN_DIGITAL_IO_INPUT), "Input Pin should be set to LOW");
 }
 
 /**
  * @brief This test is to verify digitalWrite and digitalRead functions when output pin is set to OPENDRAIN mode.
  * 
- * @note: Assumption is made that TEST_DIGITALIO_OUTPUT is connected to TEST_DIGITALIO_INPUT
+ * @note: Assumption is made that TEST_PIN_DIGITAL_IO_OUTPUT is connected to TEST_PIN_DIGITAL_IO_INPUT
  *       for the test cases to work as expected.
  */
 TEST_IFX(digitalio_single_internal, test_digitalio_read_write_output_opendrain)
 {
-    pinMode(TEST_DIGITALIO_OUTPUT, OUTPUT_OPENDRAIN);
-    pinMode(TEST_DIGITALIO_INPUT, INPUT);
+    pinMode(TEST_PIN_DIGITAL_IO_OUTPUT, OUTPUT_OPENDRAIN);
+    pinMode(TEST_PIN_DIGITAL_IO_INPUT, INPUT);
 
-    TEST_ASSERT_EQUAL_MESSAGE(LOW, digitalRead(TEST_DIGITALIO_INPUT), "Input Pin should be set to LOW initially");
+    TEST_ASSERT_EQUAL_MESSAGE(LOW, digitalRead(TEST_PIN_DIGITAL_IO_INPUT), "Input Pin should be set to LOW initially");
 
-    digitalWrite(TEST_DIGITALIO_OUTPUT, HIGH);
-    TEST_ASSERT_EQUAL_MESSAGE(HIGH, digitalRead(TEST_DIGITALIO_INPUT), "Input Pin should be set to HIGH");
-    digitalWrite(TEST_DIGITALIO_OUTPUT, LOW);
-    TEST_ASSERT_EQUAL_MESSAGE(LOW, digitalRead(TEST_DIGITALIO_INPUT), "Input Pin should be set to LOW");
+    digitalWrite(TEST_PIN_DIGITAL_IO_OUTPUT, HIGH);
+    TEST_ASSERT_EQUAL_MESSAGE(HIGH, digitalRead(TEST_PIN_DIGITAL_IO_INPUT), "Input Pin should be set to HIGH");
+    digitalWrite(TEST_PIN_DIGITAL_IO_OUTPUT, LOW);
+    TEST_ASSERT_EQUAL_MESSAGE(LOW, digitalRead(TEST_PIN_DIGITAL_IO_INPUT), "Input Pin should be set to LOW");
 }
 
 /**
@@ -146,7 +146,7 @@ TEST_IFX(digitalio_single_internal, test_digitalRead_invalid_pin) {
  * @brief Test invalid pin mode
 */
 TEST_IFX(digitalio_single_internal, test_invalid_pinmode) {
-    pinMode(TEST_DIGITALIO_INPUT, 255);
+    pinMode(TEST_PIN_DIGITAL_IO_INPUT, 255);
     // No assertion as pinMode doesn't return a value, but ensure no crash
 }
 

--- a/src/corelibs/interrupts/test_interrupts_single.cpp
+++ b/src/corelibs/interrupts/test_interrupts_single.cpp
@@ -1,7 +1,7 @@
 /* test_interrupts_single.cpp
  *
  * This test is used to verify the functionality of the GPIO Interrupts.
- * TEST_DIGITALIO_OUTPUT pin should be connected to TEST_DIGITALIO_INPUT pin
+ * TEST_PIN_DIGITAL_IO_OUTPUT pin should be connected to TEST_PIN_DIGITAL_IO_INPUT pin
  * for the test cases to work as expected.
  */
 
@@ -33,8 +33,8 @@ TEST_GROUP(gpio_interrupts_single_internal);
  */
 static TEST_SETUP(gpio_interrupts_single_internal)
 { 
-    pinMode(TEST_DIGITALIO_OUTPUT, OUTPUT);
-    pinMode(TEST_DIGITALIO_INPUT, INPUT);
+    pinMode(TEST_PIN_DIGITAL_IO_OUTPUT, OUTPUT);
+    pinMode(TEST_PIN_DIGITAL_IO_INPUT, INPUT);
     interrupt_triggered = false;
 }
 
@@ -56,21 +56,21 @@ void interrupt_callback() {
  */
 TEST_IFX(gpio_interrupts_single_internal, test_attach_interrupt_rising_edge)
 {
-    digitalWrite(TEST_DIGITALIO_OUTPUT, LOW); // initial state
+    digitalWrite(TEST_PIN_DIGITAL_IO_OUTPUT, LOW); // initial state
 
-    attachInterrupt(TEST_DIGITALIO_INPUT, interrupt_callback, RISING);
+    attachInterrupt(TEST_PIN_DIGITAL_IO_INPUT, interrupt_callback, RISING);
 
-    digitalWrite(TEST_DIGITALIO_OUTPUT, HIGH); // triggers interrupt
+    digitalWrite(TEST_PIN_DIGITAL_IO_OUTPUT, HIGH); // triggers interrupt
     delay(100);
     TEST_ASSERT_TRUE_MESSAGE(interrupt_triggered, "Interrupt should be triggered");
 
     // detach interrupt and test
-    digitalWrite(TEST_DIGITALIO_OUTPUT, LOW); // initial state
+    digitalWrite(TEST_PIN_DIGITAL_IO_OUTPUT, LOW); // initial state
 
-    detachInterrupt(TEST_DIGITALIO_INPUT);
+    detachInterrupt(TEST_PIN_DIGITAL_IO_INPUT);
 
     interrupt_triggered = false;
-    digitalWrite(TEST_DIGITALIO_OUTPUT, HIGH);
+    digitalWrite(TEST_PIN_DIGITAL_IO_OUTPUT, HIGH);
     delay(100);
     TEST_ASSERT_FALSE_MESSAGE(interrupt_triggered, "Interrupt should not be triggered after detach");
 }
@@ -80,20 +80,20 @@ TEST_IFX(gpio_interrupts_single_internal, test_attach_interrupt_rising_edge)
  */
 TEST_IFX(gpio_interrupts_single_internal, test_attach_interrupt_falling_edge)
 {
-    digitalWrite(TEST_DIGITALIO_OUTPUT, HIGH); // initial state
-    attachInterrupt(TEST_DIGITALIO_INPUT, interrupt_callback, FALLING);
+    digitalWrite(TEST_PIN_DIGITAL_IO_OUTPUT, HIGH); // initial state
+    attachInterrupt(TEST_PIN_DIGITAL_IO_INPUT, interrupt_callback, FALLING);
 
-    digitalWrite(TEST_DIGITALIO_OUTPUT, LOW); // triggers interrupt
+    digitalWrite(TEST_PIN_DIGITAL_IO_OUTPUT, LOW); // triggers interrupt
     delay(100);
     TEST_ASSERT_TRUE_MESSAGE(interrupt_triggered, "Interrupt should be triggered");
 
     // detach interrupt and test
-    digitalWrite(TEST_DIGITALIO_OUTPUT, HIGH); // initial state
+    digitalWrite(TEST_PIN_DIGITAL_IO_OUTPUT, HIGH); // initial state
 
-    detachInterrupt(TEST_DIGITALIO_INPUT);
+    detachInterrupt(TEST_PIN_DIGITAL_IO_INPUT);
 
     interrupt_triggered = false;
-    digitalWrite(TEST_DIGITALIO_OUTPUT, LOW);
+    digitalWrite(TEST_PIN_DIGITAL_IO_OUTPUT, LOW);
     delay(100);
     TEST_ASSERT_FALSE_MESSAGE(interrupt_triggered, "Interrupt should not be triggered after detach");
 }
@@ -103,29 +103,29 @@ TEST_IFX(gpio_interrupts_single_internal, test_attach_interrupt_falling_edge)
  */
 TEST_IFX(gpio_interrupts_single_internal, test_attach_interrupt_change_edge)
 {
-    digitalWrite(TEST_DIGITALIO_OUTPUT, LOW); // initial state
+    digitalWrite(TEST_PIN_DIGITAL_IO_OUTPUT, LOW); // initial state
 
-    attachInterrupt(TEST_DIGITALIO_INPUT, interrupt_callback, CHANGE);
+    attachInterrupt(TEST_PIN_DIGITAL_IO_INPUT, interrupt_callback, CHANGE);
 
-    digitalWrite(TEST_DIGITALIO_OUTPUT, HIGH); // triggers interrupt
+    digitalWrite(TEST_PIN_DIGITAL_IO_OUTPUT, HIGH); // triggers interrupt
     delay(100);
     TEST_ASSERT_TRUE_MESSAGE(interrupt_triggered, "Interrupt should be triggered");
 
     interrupt_triggered = false;
-    digitalWrite(TEST_DIGITALIO_OUTPUT, LOW); // triggers interrupt
+    digitalWrite(TEST_PIN_DIGITAL_IO_OUTPUT, LOW); // triggers interrupt
     delay(100);
     TEST_ASSERT_TRUE_MESSAGE(interrupt_triggered, "Interrupt should be triggered");
 
     interrupt_triggered = false;
-    digitalWrite(TEST_DIGITALIO_OUTPUT, HIGH); // triggers interrupt
+    digitalWrite(TEST_PIN_DIGITAL_IO_OUTPUT, HIGH); // triggers interrupt
     delay(100);
     TEST_ASSERT_TRUE_MESSAGE(interrupt_triggered, "Interrupt should be triggered");
 
     // detach interrupt and test
     interrupt_triggered = false;
-    detachInterrupt(TEST_DIGITALIO_INPUT);
+    detachInterrupt(TEST_PIN_DIGITAL_IO_INPUT);
 
-    digitalWrite(TEST_DIGITALIO_OUTPUT, HIGH);
+    digitalWrite(TEST_PIN_DIGITAL_IO_OUTPUT, HIGH);
     delay(100);
     TEST_ASSERT_FALSE_MESSAGE(interrupt_triggered, "Interrupt should not be triggered after detach");
 }
@@ -135,13 +135,13 @@ TEST_IFX(gpio_interrupts_single_internal, test_attach_interrupt_change_edge)
  */
 TEST_IFX(gpio_interrupts_single_internal, test_attach_interrupt_invalid_mode)
 {
-    digitalWrite(TEST_DIGITALIO_OUTPUT, LOW); // initial state
+    digitalWrite(TEST_PIN_DIGITAL_IO_OUTPUT, LOW); // initial state
 
-    attachInterrupt(TEST_DIGITALIO_INPUT, interrupt_callback, (PinStatus) 255);
+    attachInterrupt(TEST_PIN_DIGITAL_IO_INPUT, interrupt_callback, (PinStatus) 255);
 
-    digitalWrite(TEST_DIGITALIO_OUTPUT, HIGH); 
+    digitalWrite(TEST_PIN_DIGITAL_IO_OUTPUT, HIGH); 
     delay(100);
-    digitalWrite(TEST_DIGITALIO_OUTPUT, LOW); 
+    digitalWrite(TEST_PIN_DIGITAL_IO_OUTPUT, LOW); 
     delay(100);
     TEST_ASSERT_FALSE_MESSAGE(interrupt_triggered, "Interrupt should not be triggered when invalid mode is set");
 
@@ -152,12 +152,12 @@ TEST_IFX(gpio_interrupts_single_internal, test_attach_interrupt_invalid_mode)
  */
 TEST_IFX(gpio_interrupts_single_internal, test_attach_interrupt_invalid_pin)
 {
-    digitalWrite(TEST_DIGITALIO_OUTPUT, LOW);
+    digitalWrite(TEST_PIN_DIGITAL_IO_OUTPUT, LOW);
 
     attachInterrupt(255, interrupt_callback, RISING); // Use an invalid pin number
 
     // Trigger the interrupt by writing HIGH to the output pin
-    digitalWrite(TEST_DIGITALIO_OUTPUT, HIGH);
+    digitalWrite(TEST_PIN_DIGITAL_IO_OUTPUT, HIGH);
 
     // Small delay to ensure the interrupt is processed
     delay(100);
@@ -171,8 +171,8 @@ TEST_IFX(gpio_interrupts_single_internal, test_attach_interrupt_invalid_pin)
  */
 TEST_IFX(gpio_interrupts_single_internal, test_digital_pin_to_interrupt)
 {
-    int interrupt_number = digitalPinToInterrupt(TEST_DIGITALIO_INPUT);
-    TEST_ASSERT_EQUAL_MESSAGE(TEST_DIGITALIO_INPUT, interrupt_number, "Interrupt number should match the input pin");
+    int interrupt_number = digitalPinToInterrupt(TEST_PIN_DIGITAL_IO_INPUT);
+    TEST_ASSERT_EQUAL_MESSAGE(TEST_PIN_DIGITAL_IO_INPUT, interrupt_number, "Interrupt number should match the input pin");
 
     int invalid_interrupt_number = digitalPinToInterrupt(255); // Use an invalid pin number
     TEST_ASSERT_EQUAL_MESSAGE(-1, invalid_interrupt_number, "Interrupt number should be -1 for invalid pin");

--- a/src/corelibs/spi/test_spi_connected2_masterpingpong.cpp
+++ b/src/corelibs/spi/test_spi_connected2_masterpingpong.cpp
@@ -29,19 +29,19 @@ static uint8_t expectedReceiveBuff[MAX_BUFFER_SIZE] = {0};
 
 // Method invoked before a test suite is run.
 static void spi_connected2_masterpingpong_suite_setup() {
-    pinMode(TEST_SPI_SLAVE_SELECT, OUTPUT);
-    pinMode(TEST_SYNC_INPUT_OUTPUT, OUTPUT);
+    pinMode(TEST_PIN_SPI_SSEL, OUTPUT);
+    pinMode(TEST_PIN_SYNC_IO, OUTPUT);
     spi_master = &SPI;
 
-    digitalWrite(TEST_SPI_SLAVE_SELECT, HIGH);
-    digitalWrite(TEST_SYNC_INPUT_OUTPUT, LOW);
+    digitalWrite(TEST_PIN_SPI_SSEL, HIGH);
+    digitalWrite(TEST_PIN_SYNC_IO, LOW);
     spi_master->begin();
 }
 
 // Method invoked after a test suite is run.
 static void spi_connected2_masterpingpong_suite_teardown() {
-    digitalWrite(TEST_SPI_SLAVE_SELECT, HIGH);
-    digitalWrite(TEST_SYNC_INPUT_OUTPUT, LOW);
+    digitalWrite(TEST_PIN_SPI_SSEL, HIGH);
+    digitalWrite(TEST_PIN_SYNC_IO, LOW);
     spi_master->end();
 }
 
@@ -74,25 +74,25 @@ TEST_IFX(spi_connected2_masterpingpong, test_ping_pong_transfer_byte) {
     uint8_t testReceiveByte = 0xCC;
     uint8_t expectedReceiveByte = testReceiveByte;
 
-    digitalWrite(TEST_SYNC_INPUT_OUTPUT, HIGH);
+    digitalWrite(TEST_PIN_SYNC_IO, HIGH);
 
-    digitalWrite(TEST_SPI_SLAVE_SELECT, LOW);
+    digitalWrite(TEST_PIN_SPI_SSEL, LOW);
     testReceiveByte =  spi_master->transfer(testTransmitByte); // first byte received is dummy and ignored
-    digitalWrite(TEST_SPI_SLAVE_SELECT, HIGH);
+    digitalWrite(TEST_PIN_SPI_SSEL, HIGH);
 
     for (uint8_t i = 1; i < MAX_TEST_ITERATION; i++) {   
         testTransmitByte++;
         
-        digitalWrite(TEST_SPI_SLAVE_SELECT, LOW);
+        digitalWrite(TEST_PIN_SPI_SSEL, LOW);
         testReceiveByte = spi_master->transfer(testTransmitByte);
-        digitalWrite(TEST_SPI_SLAVE_SELECT, HIGH);
+        digitalWrite(TEST_PIN_SPI_SSEL, HIGH);
 
         TEST_ASSERT_EQUAL_UINT8_MESSAGE(expectedReceiveByte, testReceiveByte, "SPI Master PingPong transfer byte failed");
 
         expectedReceiveByte = testReceiveByte + 1; // slave increments the previously transmitted byte from slave
     }
 
-    digitalWrite(TEST_SYNC_INPUT_OUTPUT, LOW);
+    digitalWrite(TEST_PIN_SYNC_IO, LOW);
 }
 
 
@@ -115,20 +115,20 @@ TEST_IFX(spi_connected2_masterpingpong, test_ping_pong_transfer_word) {
     uint16_t expectedReceiveWord = testReceiveWord;
     uint16_t result = 0;
 
-    digitalWrite(TEST_SYNC_INPUT_OUTPUT, HIGH);
+    digitalWrite(TEST_PIN_SYNC_IO, HIGH);
 
-    digitalWrite(TEST_SPI_SLAVE_SELECT, LOW);
+    digitalWrite(TEST_PIN_SPI_SSEL, LOW);
     testReceiveWord =  spi_master->transfer16(testTransmitWord); // first byte received is dummy and ignored
-    digitalWrite(TEST_SPI_SLAVE_SELECT, HIGH);
+    digitalWrite(TEST_PIN_SPI_SSEL, HIGH);
 
 
     for (uint8_t i = 1; i < MAX_TEST_ITERATION; i++) {
         testTransmitWord++;
         result = testReceiveWord << 8;
 
-        digitalWrite(TEST_SPI_SLAVE_SELECT, LOW);
+        digitalWrite(TEST_PIN_SPI_SSEL, LOW);
         testReceiveWord = spi_master->transfer16(testTransmitWord);
-        digitalWrite(TEST_SPI_SLAVE_SELECT, HIGH);
+        digitalWrite(TEST_PIN_SPI_SSEL, HIGH);
 
         result = result | testReceiveWord >> 8; // combine the two bytes to form a 16-bit word
 
@@ -137,7 +137,7 @@ TEST_IFX(spi_connected2_masterpingpong, test_ping_pong_transfer_word) {
         expectedReceiveWord = result + 1; // slave increments the previously transmitted word from slave
     }
 
-    digitalWrite(TEST_SYNC_INPUT_OUTPUT, LOW);
+    digitalWrite(TEST_PIN_SYNC_IO, LOW);
 }
 
 
@@ -158,13 +158,13 @@ TEST_IFX(spi_connected2_masterpingpong, test_ping_pong_transfer_buffer) {
         expectedReceiveBuff[i] = 0xBB + i;
     }
 
-    digitalWrite(TEST_SYNC_INPUT_OUTPUT, HIGH);
+    digitalWrite(TEST_PIN_SYNC_IO, HIGH);
 
-    digitalWrite(TEST_SPI_SLAVE_SELECT, LOW);
+    digitalWrite(TEST_PIN_SPI_SSEL, LOW);
     spi_master->transfer(testTransmitBuff, MAX_BUFFER_SIZE+1); 
-    digitalWrite(TEST_SPI_SLAVE_SELECT, HIGH);
+    digitalWrite(TEST_PIN_SPI_SSEL, HIGH);
 
-    digitalWrite(TEST_SYNC_INPUT_OUTPUT, LOW);
+    digitalWrite(TEST_PIN_SYNC_IO, LOW);
 
     TEST_ASSERT_EQUAL_UINT8_ARRAY_MESSAGE(expectedReceiveBuff, testTransmitBuff+1, MAX_BUFFER_SIZE, "SPI Master PingPong transfer word failed");
 }

--- a/src/corelibs/spi/test_spi_connected2_slavepingpong.cpp
+++ b/src/corelibs/spi/test_spi_connected2_slavepingpong.cpp
@@ -25,12 +25,12 @@ const uint8_t MAX_TEST_ITERATION = 10;
 
 static uint8_t testTransmitBuff[MAX_BUFFER_SIZE] = {0};
 static uint8_t expectedReceiveBuff[MAX_BUFFER_SIZE] = {0};
-static SPIClassPSOC SPI1 = SPIClassPSOC(PIN_SPI_MOSI, PIN_SPI_MISO, PIN_SPI_SCK, TEST_SPI_SLAVE_SELECT, true);
+static SPIClassPSOC SPI1 = SPIClassPSOC(PIN_SPI_MOSI, PIN_SPI_MISO, PIN_SPI_SCK, TEST_PIN_SPI_SSEL, true);
 static SPIClassPSOC *spi_slave = &SPI1;
 
 // Method invoked before a test suite is run.
 static void spi_connected2_slavepingpong_suite_setup() {
-    pinMode(TEST_SYNC_INPUT_OUTPUT, INPUT_PULLDOWN);
+    pinMode(TEST_PIN_SYNC_IO, INPUT_PULLDOWN);
     spi_slave->begin();
 }
 
@@ -63,7 +63,7 @@ TEST_IFX(spi_connected2_slavepingpong, test_ping_pong_transfer_byte) {
     uint8_t testReceiveByte = 0xAA;
     uint8_t expectedReceiveByte = testReceiveByte;
     
-    while (digitalRead(TEST_SYNC_INPUT_OUTPUT) == LOW) {
+    while (digitalRead(TEST_PIN_SYNC_IO) == LOW) {
         // Wait for the master to pull the sync pin high
     }
 
@@ -91,7 +91,7 @@ TEST_IFX(spi_connected2_slavepingpong, test_ping_pong_transfer_word) {
     uint16_t testReceiveWord = 0x4433; // first word read from master
     uint16_t expectedReceiveWord = testReceiveWord;
     
-    while (digitalRead(TEST_SYNC_INPUT_OUTPUT) == LOW) {
+    while (digitalRead(TEST_PIN_SYNC_IO) == LOW) {
         // Wait for the master to pull the sync pin high
     }
 
@@ -116,7 +116,7 @@ TEST_IFX(spi_connected2_slavepingpong, test_ping_pong_transfer_buffer) {
         expectedReceiveBuff[i] = 0xAA + i;
     }
 
-    while (digitalRead(TEST_SYNC_INPUT_OUTPUT) == LOW) {
+    while (digitalRead(TEST_PIN_SYNC_IO) == LOW) {
         // Wait for the master to pull the sync pin high
     }
 

--- a/src/corelibs/uart/test_uart_rx.cpp
+++ b/src/corelibs/uart/test_uart_rx.cpp
@@ -58,8 +58,8 @@ static TEST_TEAR_DOWN(uart_rx) {
  * And that can lead to potential reception of invalid data.
  */
 TEST_IFX(uart_rx, wait_for_synch_signal) {
-    pinMode(TEST_SYNC_INPUT_OUTPUT, INPUT_PULLDOWN);
-    while (digitalRead(TEST_SYNC_INPUT_OUTPUT) == LOW) {}
+    pinMode(TEST_PIN_SYNC_IO, INPUT_PULLDOWN);
+    while (digitalRead(TEST_PIN_SYNC_IO) == LOW) {}
 }
 
 TEST_IFX(uart_rx, begin) {

--- a/src/corelibs/uart/test_uart_tx.cpp
+++ b/src/corelibs/uart/test_uart_tx.cpp
@@ -44,12 +44,12 @@
 TEST_GROUP(uart_tx);
 
 static void uart_tx_suite_setup() {
-    pinMode(TEST_SYNC_INPUT_OUTPUT, OUTPUT);
-    digitalWrite(TEST_SYNC_INPUT_OUTPUT, LOW);
+    pinMode(TEST_PIN_SYNC_IO, OUTPUT);
+    digitalWrite(TEST_PIN_SYNC_IO, LOW);
 }
 
 static void uart_tx_suite_teardown() {
-    digitalWrite(TEST_SYNC_INPUT_OUTPUT, LOW);
+    digitalWrite(TEST_PIN_SYNC_IO, LOW);
 }
 
 static TEST_SETUP(uart_tx) {
@@ -66,7 +66,7 @@ static TEST_TEAR_DOWN(uart_tx) {
  * And that can lead to potential reception of invalid data.
  */
 TEST_IFX(uart_tx, notify_readiness_to_uart_rx) {
-    digitalWrite(TEST_SYNC_INPUT_OUTPUT, HIGH);
+    digitalWrite(TEST_PIN_SYNC_IO, HIGH);
     /* Let some time for the other to initialize 
     and be ready for the communication. */
     delay(500);

--- a/src/test_main.ino
+++ b/src/test_main.ino
@@ -22,9 +22,9 @@ void RunAllTests(void)
 
 #endif
 
-#ifdef TEST_ANALOGIO_SINGLE
+#ifdef TEST_ANALOGIO_ADC
 
-    RUN_TEST_GROUP(analogio_single);
+    RUN_TEST_GROUP(analogio_adc);
 
 #endif
 

--- a/src/test_main.ino
+++ b/src/test_main.ino
@@ -28,6 +28,12 @@ void RunAllTests(void)
 
 #endif
 
+#ifdef TEST_ANALOGIO_PWM
+
+    RUN_TEST_GROUP(analogio_pwm);
+
+#endif
+
 #ifdef TEST_INTERRUPTS_SINGLE
 
     RUN_TEST_GROUP(gpio_interrupts_single);


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Added PWM tests for APIs :
1. AnalogWrite(pin, value);
2. AnalogWriteResolution(res);

Additionally refactored a little. Mainly:
1. pin renaming across files
2. test_analogio_single renamed to test_analogio_pwm

![analog_write](https://github.com/user-attachments/assets/d58478fb-89e6-4e7a-8d60-e42bd14a1302)
