### PR TITLE
src/corelibs/uart: Added XMC arch.

### DIFF
--- a/src/corelibs/uart/test_uart_rx.cpp
+++ b/src/corelibs/uart/test_uart_rx.cpp
@@ -150,6 +150,16 @@ TEST_IFX(uart_rx, read_longer_than_writable) {
                  "after a few calls to Serial.print() or Serial.println() "
                  "with small amount of bytes, the TX buffer seems to "
                  "overflow and the Serial output becomes corrupted.";
+    #elif defined(ARDUINO_ARCH_XMC)
+    char expected_msg[] = "This is a very long string that is meant to be longer "
+                 "than the writable buffer of the UART. "
+                 "The Serial class API provides the mechanisms for "
+                 "user level flow control by availableForWrite(), "
+                 "flush() and the return of the actual bytes written. "
+                 "Still, for some cores, the experience is that only "
+                 "after a few calls to Serial.print() or Serial.println() "
+                 "with small amount of bytes, the TX buffer seems to "
+                 "overflow and the Serial output becomes corrupted.";
     #else
     char expected_msg[] = "This is a (not so) long string example. Adjust length as per core.";
     #endif

--- a/src/corelibs/uart/test_uart_rx.cpp
+++ b/src/corelibs/uart/test_uart_rx.cpp
@@ -140,17 +140,7 @@ TEST_IFX(uart_rx, wait_for_println) {
  *       This depends on the core implementation.
  */
 TEST_IFX(uart_rx, read_longer_than_writable) {
-    #if defined(ARDUINO_ARCH_PSOC6)
-    char expected_msg[] = "This is a very long string that is meant to be longer "
-                 "than the writable buffer of the UART. "
-                 "The Serial class API provides the mechanisms for "
-                 "user level flow control by availableForWrite(), "
-                 "flush() and the return of the actual bytes written. "
-                 "Still, for some cores, the experience is that only "
-                 "after a few calls to Serial.print() or Serial.println() "
-                 "with small amount of bytes, the TX buffer seems to "
-                 "overflow and the Serial output becomes corrupted.";
-    #elif defined(ARDUINO_ARCH_XMC)
+    #if defined(ARDUINO_ARCH_PSOC6) || defined(ARDUINO_ARCH_XMC)
     char expected_msg[] = "This is a very long string that is meant to be longer "
                  "than the writable buffer of the UART. "
                  "The Serial class API provides the mechanisms for "

--- a/src/corelibs/uart/test_uart_tx.cpp
+++ b/src/corelibs/uart/test_uart_tx.cpp
@@ -150,17 +150,7 @@ TEST_IFX(uart_tx, availableForWrite) {
  *       This depends on the core implementation.
  */
 TEST_IFX(uart_tx, write_longer_than_writable) {
-    #if defined(ARDUINO_ARCH_PSOC6)
-    char msg[] = "This is a very long string that is meant to be longer "
-                 "than the writable buffer of the UART. "
-                 "The Serial class API provides the mechanisms for "
-                 "user level flow control by availableForWrite(), "
-                 "flush() and the return of the actual bytes written. "
-                 "Still, for some cores, the experience is that only "
-                 "after a few calls to Serial.print() or Serial.println() "
-                 "with small amount of bytes, the TX buffer seems to "
-                 "overflow and the Serial output becomes corrupted.";
-    #elif defined (ARDUINO_ARCH_XMC)
+    #if defined(ARDUINO_ARCH_PSOC6) || defined (ARDUINO_ARCH_XMC)
     char msg[] = "This is a very long string that is meant to be longer "
                  "than the writable buffer of the UART. "
                  "The Serial class API provides the mechanisms for "

--- a/src/corelibs/uart/test_uart_tx.cpp
+++ b/src/corelibs/uart/test_uart_tx.cpp
@@ -135,6 +135,8 @@ TEST_IFX(uart_tx, availableForWrite) {
     /* The value 128 is the max value. 
        Only when sufficient time has elapsed after writing.*/
     uint8_t expected_writable = 128;
+    #elif defined(ARDUINO_ARCH_XMC)
+    uint8_t expected_writable = 1;
     #else
     /* Inherited implementation */
     uint8_t expected_writable = 0;
@@ -149,6 +151,16 @@ TEST_IFX(uart_tx, availableForWrite) {
  */
 TEST_IFX(uart_tx, write_longer_than_writable) {
     #if defined(ARDUINO_ARCH_PSOC6)
+    char msg[] = "This is a very long string that is meant to be longer "
+                 "than the writable buffer of the UART. "
+                 "The Serial class API provides the mechanisms for "
+                 "user level flow control by availableForWrite(), "
+                 "flush() and the return of the actual bytes written. "
+                 "Still, for some cores, the experience is that only "
+                 "after a few calls to Serial.print() or Serial.println() "
+                 "with small amount of bytes, the TX buffer seems to "
+                 "overflow and the Serial output becomes corrupted.";
+    #elif defined (ARDUINO_ARCH_XMC)
     char msg[] = "This is a very long string that is meant to be longer "
                  "than the writable buffer of the UART. "
                  "The Serial class API provides the mechanisms for "


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Defined XMC architecture in UART both rx and tx test cases for understandable. 
Related Issue
availableforwrite() directly return 1 byte in uart.cpp file(XMC).
Context
after modification tested with two 4700 kit, 
Connection: RX - TX and synchronize pin
![image](https://github.com/user-attachments/assets/a7b67dfd-103a-4442-bb3c-dcb5081ef046)
