### PR TITLE
src/corelibs/interrupts: Modified interrupt testcase for XMC.

### DIFF
--- a/src/corelibs/interrupts/test_interrupts_single.cpp
+++ b/src/corelibs/interrupts/test_interrupts_single.cpp
@@ -172,15 +172,12 @@ TEST_IFX(gpio_interrupts_single_internal, test_digital_pin_to_interrupt)
     int interrupt_number = digitalPinToInterrupt(TEST_PIN_DIGITAL_IO_INPUT);
     TEST_ASSERT_LESS_OR_EQUAL_INT(1, interrupt_number);
     TEST_ASSERT_GREATER_OR_EQUAL_INT(0, interrupt_number);
-    int invalid_interrupt_number = digitalPinToInterrupt(255); // Use an invalid pin number
-    TEST_ASSERT_EQUAL_MESSAGE(-1, invalid_interrupt_number, "Interrupt number should be -1 for invalid pin");
     #else
     int interrupt_number = digitalPinToInterrupt(TEST_PIN_DIGITAL_IO_INPUT);
     TEST_ASSERT_EQUAL_MESSAGE(TEST_PIN_DIGITAL_IO_INPUT, interrupt_number, "Interrupt number should match the input pin");
-
+    #endif
     int invalid_interrupt_number = digitalPinToInterrupt(255); // Use an invalid pin number
     TEST_ASSERT_EQUAL_MESSAGE(-1, invalid_interrupt_number, "Interrupt number should be -1 for invalid pin");
-    #endif
 }
 
 /**


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Modified Interrupt test case for XMC architecture

Related Issue
without _digitalpinInterrupt()_ function pin is not detecting properly, so included in test case.
Context
![image](https://github.com/user-attachments/assets/5c5354f1-923f-46d1-a318-25551040f091)
Tested with 4700 board, connecting single wire in-between 2 pins.