### PR TITLE
Xmc test tone

### DIFF
--- a/src/corelibs/tone/test_tone_no_tone.cpp
+++ b/src/corelibs/tone/test_tone_no_tone.cpp
@@ -219,7 +219,11 @@ TEST_IFX(tone_no_tone, test_no_tone) {
  *        The tone is expected to change frequency without stopping with duration specified.
  */
 TEST_IFX(tone_no_tone, test_tone_overlap_frequency) {
-    const unsigned int test_frequencies_hz[] = {5, 20, 10}; 
+ #if defined(ARDUINO_ARCH_XMC)
+    const unsigned int test_frequencies_hz[] = {35, 50, 39}; //XMC 4700 minimum frequency working from 35Hz
+#else
+    const unsigned int test_frequencies_hz[] = {5, 10, 20}; 
+#endif
     const unsigned int array_size = sizeof(test_frequencies_hz) / sizeof(test_frequencies_hz[0]);
     const unsigned int tone_duration_ms = 1000;
     const unsigned int delay_introduced_ms = 300;

--- a/src/corelibs/tone/test_tone_no_tone.cpp
+++ b/src/corelibs/tone/test_tone_no_tone.cpp
@@ -220,7 +220,7 @@ TEST_IFX(tone_no_tone, test_no_tone) {
  */
 TEST_IFX(tone_no_tone, test_tone_overlap_frequency) {
  #if defined(ARDUINO_ARCH_XMC)
-    const unsigned int test_frequencies_hz[] = {35, 50, 39}; //XMC 4700 minimum frequency working from 35Hz
+    const unsigned int test_frequencies_hz[] = {35, 50, 39}; //Tested with XMC 4700 minimum frequency working from 35Hz
 #else
     const unsigned int test_frequencies_hz[] = {5, 10, 20}; 
 #endif


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Added minimum frequency range for XMC architecture.
Related Issue
Less than 35 Hz not getting pass for test_tone_overlap_frequency test case.
Context
Tested with 4700 board. 
![image](https://github.com/user-attachments/assets/ee669f95-fef3-4ae1-a8fa-6889e611a76a)
