### PR TITLE
src/corelibs/analogio: Use detschInterupt() instead of noInterrupts().

### DIFF
--- a/src/corelibs/analogio/test_analogio_pwm.cpp
+++ b/src/corelibs/analogio/test_analogio_pwm.cpp
@@ -95,7 +95,7 @@ static void analogio_pwm_suite_setup() {
  * @brief Suite teardown function, runs after test suite execution is complete.
  */
 static void analogio_pwm_suite_teardown() {
-    
+    detachInterrupt(digitalPinToInterrupt(PWM_PIN_FEEDBACK));
 }
 
 // Define test group name
@@ -117,7 +117,7 @@ static TEST_SETUP(analogio_pwm) {
  * @brief Tear down method called by Unity after every test in this test group.
  */
 static TEST_TEAR_DOWN(analogio_pwm) {
-    noInterrupts();
+
 }
 
 /**


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
delay() is not working after noInterrupt(). So we change to detschInterupt() 

Related Issue
-
Context
-