### PR TITLE
src/corelibs/tone: Removed interrupt in teardown.

### DIFF
--- a/src/corelibs/tone/test_tone_no_tone.cpp
+++ b/src/corelibs/tone/test_tone_no_tone.cpp
@@ -133,7 +133,6 @@ static TEST_SETUP(tone_no_tone) {
  * @brief Tear down method called by Unity after every test in this test group.
  */
 static TEST_TEAR_DOWN(tone_no_tone) {
-    noInterrupts();
     reset_tone();
 }
 


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Removed noInterrupt() function because in XMC test case is blocking it running only once.

Related Issue
Test case not running continuously. 
Context
![image](https://github.com/user-attachments/assets/2596256a-0cba-4c60-9d24-775f7236f095)
after removed noInterrupt() test case running continuously without blocking.