### PR TITLE
Makefile: src/corelibs/spi: Remove PSOC specific class name from test…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ unity: print_args clean check_unity_path
 	$(Q) find $(UNITY_PATH) -name '*.[hc]' \( -path '*extras*' -a -path '*src*' -or -path '*src*' -a \! -path '*example*' \) -exec \cp {} build \;
 	$(Q) find src/utils -name '*.[hc]*' -exec \cp {} build \;
 	$(Q) find src -maxdepth 1 -name '*.[hc]*' -exec \cp {} build \;
-	$(Q) find ../ -maxdepth 1 -name 'test_config.h' -exec \cp {} build \;
+	$(Q) find ../ -maxdepth 1 -name 'test_config.*' -exec \cp {} build \;
 	$(Q) cp src/test_main.ino build/build.ino
 
 # Helper to extract the second word from the target name

--- a/src/corelibs/spi/test_spi_connected1_loopback.cpp
+++ b/src/corelibs/spi/test_spi_connected1_loopback.cpp
@@ -14,14 +14,14 @@
 
 // defines
 // Variables for SPI testing
-static SPIClassPSOC *spi = nullptr;
 static const uint8_t testDataByte = 0xA5; // Example test byte
 static const uint16_t testDataWord = 0x55AA; // Example test word
 static uint8_t testTranceiveBuff[8] = {0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF};
 
+SPIClass *spi = &SPI;
+
 // Setup and teardown methods for the test suite
 static void spi_test_suite_setup() {
-    spi = &SPI;
     spi->begin();
 }
 

--- a/src/corelibs/spi/test_spi_connected2_masterpingpong.cpp
+++ b/src/corelibs/spi/test_spi_connected2_masterpingpong.cpp
@@ -14,6 +14,7 @@
 
 // test includes
 #include "test_common_includes.h"
+#include "test_config.h"
 
 // project includes
 #include <SPI.h>
@@ -22,16 +23,15 @@ const uint8_t MAX_BUFFER_SIZE = 20;
 const uint8_t MAX_TEST_ITERATION = 10;
 
 // variables
-static SPIClassPSOC *spi_master = nullptr;
 static uint8_t testTransmitBuff[MAX_BUFFER_SIZE+1] = {0};
 static uint8_t expectedReceiveBuff[MAX_BUFFER_SIZE] = {0};
 
+SPIClass *spi_master = &SPI;
 
 // Method invoked before a test suite is run.
 static void spi_connected2_masterpingpong_suite_setup() {
     pinMode(TEST_PIN_SPI_SSEL, OUTPUT);
     pinMode(TEST_PIN_SYNC_IO, OUTPUT);
-    spi_master = &SPI;
 
     digitalWrite(TEST_PIN_SPI_SSEL, HIGH);
     digitalWrite(TEST_PIN_SYNC_IO, LOW);

--- a/src/corelibs/spi/test_spi_connected2_slavepingpong.cpp
+++ b/src/corelibs/spi/test_spi_connected2_slavepingpong.cpp
@@ -15,18 +15,19 @@
 // test includes
 #include "test_common_includes.h"
 #include "pins_arduino.h"
+#include "test_config.h"
 
 // project includes
 #include <SPI.h>
 
 const uint8_t MAX_BUFFER_SIZE = 20;
 const uint8_t MAX_TEST_ITERATION = 10;
-// variables
 
+// variables
 static uint8_t testTransmitBuff[MAX_BUFFER_SIZE] = {0};
 static uint8_t expectedReceiveBuff[MAX_BUFFER_SIZE] = {0};
-static SPIClassPSOC SPI1 = SPIClassPSOC(PIN_SPI_MOSI, PIN_SPI_MISO, PIN_SPI_SCK, TEST_PIN_SPI_SSEL, true);
-static SPIClassPSOC *spi_slave = &SPI1;
+
+SPIClass *spi_slave = &SPI1; 
 
 // Method invoked before a test suite is run.
 static void spi_connected2_slavepingpong_suite_setup() {


### PR DESCRIPTION
…suite.

By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

We previously used project-specific class names "SPIClassPSOC" in SPI tests to create slave and master instances. This has now been moved to a test_config source file to enhance its generic nature and reusability across different projects.

https://github.com/Infineon/arduino-core-psoc6/pull/148
