### PR TITLE
Makefile: Fix test config path.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ unity: print_args clean check_unity_path
 	$(Q) find $(UNITY_PATH) -name '*.[hc]' \( -path '*extras*' -a -path '*src*' -or -path '*src*' -a \! -path '*example*' \) -exec \cp {} build \;
 	$(Q) find src/utils -name '*.[hc]*' -exec \cp {} build \;
 	$(Q) find src -maxdepth 1 -name '*.[hc]*' -exec \cp {} build \;
-	$(Q) find ../ -maxdepth 1 -name 'test_config.*' -exec \cp {} build \;
+	$(Q) find ../../tests -maxdepth 1 -name 'test_config.*' -exec \cp {} build \;
 	$(Q) cp src/test_main.ino build/build.ino
 
 # Helper to extract the second word from the target name


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
The path fix is not merged to main, I have to add it to make hil running in xmc4arduino

Related Issue
https://github.com/Infineon/XMC-for-Arduino/actions/runs/16964859669/job/48086214479
here you can see the issue : include not found


Context