### PR TITLE
src/corelibs/spi: Added delay in master test case.

### DIFF
--- a/src/corelibs/spi/test_spi_connected2_masterpingpong.cpp
+++ b/src/corelibs/spi/test_spi_connected2_masterpingpong.cpp
@@ -18,8 +18,9 @@
 
 // project includes
 #include <SPI.h>
-#define SPI_TRANSFER_DELAY_US 2000
-
+#ifndef SPI_TRANSFER_DELAY
+#define SPI_TRANSFER_DELAY 500
+#else
 const uint8_t MAX_BUFFER_SIZE = 20;
 const uint8_t MAX_TEST_ITERATION = 10;
 

--- a/src/corelibs/spi/test_spi_connected2_masterpingpong.cpp
+++ b/src/corelibs/spi/test_spi_connected2_masterpingpong.cpp
@@ -18,6 +18,7 @@
 
 // project includes
 #include <SPI.h>
+#define SPI_TRANSFER_DELAY_US 2000
 
 const uint8_t MAX_BUFFER_SIZE = 20;
 const uint8_t MAX_TEST_ITERATION = 10;
@@ -77,18 +78,18 @@ TEST_IFX(spi_connected2_masterpingpong, test_ping_pong_transfer_byte) {
     digitalWrite(TEST_PIN_SYNC_IO, HIGH);
 
     digitalWrite(TEST_PIN_SPI_SSEL, LOW);
-    delayMicroseconds(200);
+    delayMicroseconds(SPI_TRANSFER_DELAY_US);
     testReceiveByte =  spi_master->transfer(testTransmitByte); // first byte received is dummy and ignored
-    delayMicroseconds(200);
+    delayMicroseconds(SPI_TRANSFER_DELAY_US);
     digitalWrite(TEST_PIN_SPI_SSEL, HIGH);
 
     for (uint8_t i = 1; i < MAX_TEST_ITERATION; i++) {   
         testTransmitByte++;
         
         digitalWrite(TEST_PIN_SPI_SSEL, LOW);
-        delayMicroseconds(200);
+        delayMicroseconds(SPI_TRANSFER_DELAY_US);
         testReceiveByte = spi_master->transfer(testTransmitByte);
-        delayMicroseconds(200);
+        delayMicroseconds(SPI_TRANSFER_DELAY_US);
         digitalWrite(TEST_PIN_SPI_SSEL, HIGH);
 
         TEST_ASSERT_EQUAL_UINT8_MESSAGE(expectedReceiveByte, testReceiveByte, "SPI Master PingPong transfer byte failed");
@@ -122,9 +123,9 @@ TEST_IFX(spi_connected2_masterpingpong, test_ping_pong_transfer_word) {
     digitalWrite(TEST_PIN_SYNC_IO, HIGH);
 
     digitalWrite(TEST_PIN_SPI_SSEL, LOW);
-    delayMicroseconds(2000);
+    delayMicroseconds(SPI_TRANSFER_DELAY_US);
     testReceiveWord =  spi_master->transfer16(testTransmitWord); // first byte received is dummy and ignored
-    delayMicroseconds(2000);
+    delayMicroseconds(SPI_TRANSFER_DELAY_US);
     digitalWrite(TEST_PIN_SPI_SSEL, HIGH);
 
 
@@ -133,9 +134,9 @@ TEST_IFX(spi_connected2_masterpingpong, test_ping_pong_transfer_word) {
         result = testReceiveWord << 8;
 
         digitalWrite(TEST_PIN_SPI_SSEL, LOW);
-        delayMicroseconds(2000);
+        delayMicroseconds(SPI_TRANSFER_DELAY_US);
         testReceiveWord = spi_master->transfer16(testTransmitWord);
-        delayMicroseconds(2000);
+        delayMicroseconds(SPI_TRANSFER_DELAY_US);
         digitalWrite(TEST_PIN_SPI_SSEL, HIGH);
 
         result = result | testReceiveWord >> 8; // combine the two bytes to form a 16-bit word
@@ -169,9 +170,9 @@ TEST_IFX(spi_connected2_masterpingpong, test_ping_pong_transfer_buffer) {
     digitalWrite(TEST_PIN_SYNC_IO, HIGH);
 
     digitalWrite(TEST_PIN_SPI_SSEL, LOW);
-    delayMicroseconds(2000);
+    delayMicroseconds(SPI_TRANSFER_DELAY_US);
     spi_master->transfer(testTransmitBuff, MAX_BUFFER_SIZE+1); 
-    delayMicroseconds(2000);
+    delayMicroseconds(SPI_TRANSFER_DELAY_US);
     digitalWrite(TEST_PIN_SPI_SSEL, HIGH);
 
     digitalWrite(TEST_PIN_SYNC_IO, LOW);

--- a/src/corelibs/spi/test_spi_connected2_masterpingpong.cpp
+++ b/src/corelibs/spi/test_spi_connected2_masterpingpong.cpp
@@ -77,14 +77,18 @@ TEST_IFX(spi_connected2_masterpingpong, test_ping_pong_transfer_byte) {
     digitalWrite(TEST_PIN_SYNC_IO, HIGH);
 
     digitalWrite(TEST_PIN_SPI_SSEL, LOW);
+    delayMicroseconds(200);
     testReceiveByte =  spi_master->transfer(testTransmitByte); // first byte received is dummy and ignored
+    delayMicroseconds(200);
     digitalWrite(TEST_PIN_SPI_SSEL, HIGH);
 
     for (uint8_t i = 1; i < MAX_TEST_ITERATION; i++) {   
         testTransmitByte++;
         
         digitalWrite(TEST_PIN_SPI_SSEL, LOW);
+        delayMicroseconds(200);
         testReceiveByte = spi_master->transfer(testTransmitByte);
+        delayMicroseconds(200);
         digitalWrite(TEST_PIN_SPI_SSEL, HIGH);
 
         TEST_ASSERT_EQUAL_UINT8_MESSAGE(expectedReceiveByte, testReceiveByte, "SPI Master PingPong transfer byte failed");
@@ -118,7 +122,9 @@ TEST_IFX(spi_connected2_masterpingpong, test_ping_pong_transfer_word) {
     digitalWrite(TEST_PIN_SYNC_IO, HIGH);
 
     digitalWrite(TEST_PIN_SPI_SSEL, LOW);
+    delayMicroseconds(2000);
     testReceiveWord =  spi_master->transfer16(testTransmitWord); // first byte received is dummy and ignored
+    delayMicroseconds(2000);
     digitalWrite(TEST_PIN_SPI_SSEL, HIGH);
 
 
@@ -127,7 +133,9 @@ TEST_IFX(spi_connected2_masterpingpong, test_ping_pong_transfer_word) {
         result = testReceiveWord << 8;
 
         digitalWrite(TEST_PIN_SPI_SSEL, LOW);
+        delayMicroseconds(2000);
         testReceiveWord = spi_master->transfer16(testTransmitWord);
+        delayMicroseconds(2000);
         digitalWrite(TEST_PIN_SPI_SSEL, HIGH);
 
         result = result | testReceiveWord >> 8; // combine the two bytes to form a 16-bit word
@@ -161,7 +169,9 @@ TEST_IFX(spi_connected2_masterpingpong, test_ping_pong_transfer_buffer) {
     digitalWrite(TEST_PIN_SYNC_IO, HIGH);
 
     digitalWrite(TEST_PIN_SPI_SSEL, LOW);
+    delayMicroseconds(2000);
     spi_master->transfer(testTransmitBuff, MAX_BUFFER_SIZE+1); 
+    delayMicroseconds(2000);
     digitalWrite(TEST_PIN_SPI_SSEL, HIGH);
 
     digitalWrite(TEST_PIN_SYNC_IO, LOW);


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Because of test case failing in XMC added delay in before and after transfer function.
Related Issue
XMC as master and psco as slave , while running the test its failed. so added delay.
Context
XMC-Master and PSOC 6 AI - Slave
<img width="718" height="421" alt="image" src="https://github.com/user-attachments/assets/1f1dd778-38f5-4e60-bbcf-d0eef6956e96" />
<img width="657" height="407" alt="image" src="https://github.com/user-attachments/assets/9fbf280b-81a2-4246-ab32-1e264dfec93e" />
