### PR TITLE
src/corelibs/time/: Set delay microsecound to lower number.

### DIFF
--- a/src/corelibs/time/test_time_single.cpp
+++ b/src/corelibs/time/test_time_single.cpp
@@ -74,7 +74,7 @@ TEST_IFX(time_single_internal, testDelay)
 TEST_IFX(time_single_internal, testDelayMicroseconds)
 {
     unsigned long start_time, end_time;
-    unsigned long expected_delay_us = 500000; 
+    unsigned long expected_delay_us = 500; 
 
     start_time = micros();
     delayMicroseconds(expected_delay_us);


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
change the default expected delay us to 500us which is smaller than 1ms.
success HiL check: https://github.com/Infineon/XMC-for-Arduino/actions/runs/17376590998/job/49324242252?pr=384

Related Issue
Failed HiL check before change: https://github.com/Infineon/XMC-for-Arduino/actions/runs/17207828488/job/48812305693

Context
